### PR TITLE
Make beta and prod flavours

### DIFF
--- a/MojioSDK/app/mojiosdksrc.iml
+++ b/MojioSDK/app/mojiosdksrc.iml
@@ -8,15 +8,15 @@
     </facet>
     <facet type="android" name="Android">
       <configuration>
-        <option name="SELECTED_BUILD_VARIANT" value="debug" />
+        <option name="SELECTED_BUILD_VARIANT" value="betaDebug" />
         <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
-        <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
-        <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
-        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugAndroidTest" />
-        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileDebugAndroidTestSources" />
+        <option name="ASSEMBLE_TASK_NAME" value="assembleBetaDebug" />
+        <option name="COMPILE_JAVA_TASK_NAME" value="compileBetaDebugSources" />
+        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleBetaDebugAndroidTest" />
+        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileBetaDebugAndroidTestSources" />
         <afterSyncTasks>
-          <task>generateDebugAndroidTestSources</task>
-          <task>generateDebugSources</task>
+          <task>generateBetaDebugAndroidTestSources</task>
+          <task>generateBetaDebugSources</task>
         </afterSyncTasks>
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
@@ -28,22 +28,43 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/classes/debug" />
-    <output-test url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/classes/androidTest/debug" />
+    <output url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/classes/beta/debug" />
+    <output-test url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/classes/androidTest/beta/debug" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../mojiosdksrc">
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/r/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/aidl/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/rs/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/res/rs/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/res/generated/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/r/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/res/generated/androidTest/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/r/beta/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/aidl/beta/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/buildConfig/beta/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/rs/beta/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/res/rs/beta/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/res/resValues/beta/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/betaDebug/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/betaDebug/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/betaDebug/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/betaDebug/aidl" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/betaDebug/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/betaDebug/jni" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/betaDebug/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/r/androidTest/beta/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/aidl/androidTest/beta/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/buildConfig/androidTest/beta/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/rs/androidTest/beta/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/res/rs/androidTest/beta/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/res/resValues/androidTest/beta/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/beta/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/beta/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/beta/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/beta/aidl" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/beta/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/beta/jni" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/beta/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTestBeta/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTestBeta/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTestBeta/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTestBeta/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTestBeta/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTestBeta/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTestBeta/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/debug/assets" type="java-resource" />
@@ -72,6 +93,7 @@
       <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/dex" />
       <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/dex-cache" />
+      <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/exploded-aar/client.signalr.aspnet.microsoft.signalr_client_sdk_android/signalr-client-sdk-android-release/1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/incremental" />
       <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/jacoco" />
       <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/javaResources" />

--- a/MojioSDK/build.gradle
+++ b/MojioSDK/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:1.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/MojioSDK/libraries/libraries.iml
+++ b/MojioSDK/libraries/libraries.iml
@@ -37,13 +37,13 @@
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/generated/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/generated/androidTest/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
@@ -72,6 +72,8 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex-cache" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/21.0.3/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/21.0.3/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaResources" />

--- a/MojioSDK/mojiosdksrc/build.gradle
+++ b/MojioSDK/mojiosdksrc/build.gradle
@@ -2,8 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.1"
-
+    buildToolsVersion "21.1.2"
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 21
@@ -16,6 +15,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    productFlavors {
+        beta { }
+        prod { }
+    }
 }
 
 repositories{
@@ -25,12 +28,11 @@ repositories{
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
+    compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:21.0.3'
     compile 'com.google.code.gson:gson:2.2.4'
     compile 'com.mcxiaoke.volley:library:1.0.6'
     compile 'joda-time:joda-time:2.5'
-
     compile project(':libraries')
     compile 'client.signalr.aspnet.microsoft.signalr_client_sdk_android:signalr-client-sdk-android-release:1.0@aar'
 }

--- a/MojioSDK/mojiosdksrc/src/beta/java/io/moj/mobile/android/sdk/enums/Endpoint.java
+++ b/MojioSDK/mojiosdksrc/src/beta/java/io/moj/mobile/android/sdk/enums/Endpoint.java
@@ -1,0 +1,64 @@
+package io.moj.mobile.android.sdk.enums;
+
+import android.content.Context;
+import android.text.TextUtils;
+import android.util.Log;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.Set;
+
+import io.moj.mobile.android.sdk.R;
+
+/**
+ * An enumeration of different backend endpoints for the Mojio API.
+ * Created by skidson on 15-09-21.
+ */
+public enum Endpoint {
+
+    NA("api.moj.io", true, R.array.iso3166_alpha3_na, R.array.iso3166_alpha2_na, R.array.iso639_1_na),
+    EU("cz-api.moj.io", false, R.array.iso3166_alpha3_eu, R.array.iso3166_alpha2_eu, R.array.iso639_1_eu);
+
+    private static final String TAG = Endpoint.class.getSimpleName();
+
+    private final String apiUrl;
+    private final boolean sandboxAvailable;
+    private final int iso3CountriesResId;
+    private final int iso2CountriesResId;
+    private final int iso2LanguagesResId;
+
+    Endpoint(String apiUrl, boolean sandboxAvailable, int iso3CountriesResId, int iso2CountriesResId, int iso2LanguagesResId) {
+        this.apiUrl = apiUrl;
+        this.sandboxAvailable = sandboxAvailable;
+        this.iso3CountriesResId = iso3CountriesResId;
+        this.iso2CountriesResId = iso2CountriesResId;
+        this.iso2LanguagesResId = iso2LanguagesResId;
+    }
+
+    public boolean isSandboxAvailable() {
+        return sandboxAvailable;
+    }
+
+    public String getApiUrl() {
+        return apiUrl;
+    }
+
+    public int getIso3CountriesResId() {
+        return iso3CountriesResId;
+    }
+
+    public int getIso2CountriesResId() {
+        return iso2CountriesResId;
+    }
+
+    public int getIso2LanguagesResId() {
+            return iso2LanguagesResId;
+        }
+
+    public static Endpoint fromLocale(Context context, Locale locale) {
+        // for Beta we are always using EU
+        return EU;
+    }
+}

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/MojioClient.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/MojioClient.java
@@ -7,7 +7,6 @@ import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.text.TextUtils;
 import android.util.Log;
 
 import com.android.volley.Request;
@@ -20,15 +19,12 @@ import com.google.gson.JsonObject;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
-import java.util.MissingResourceException;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import io.moj.mobile.android.sdk.enums.Endpoint;
 import io.moj.mobile.android.sdk.models.Observers.Observer;
 import io.moj.mobile.android.sdk.models.User;
 import io.moj.mobile.android.sdk.models.UserToken;
@@ -122,45 +118,6 @@ public class MojioClient {
         updateLocale(ctx.getResources().getConfiguration().locale);
     }
 
-    private enum Endpoint {
-        NA("api.moj.io", true, R.array.iso3166_alpha3_na, R.array.iso3166_alpha2_na, R.array.iso639_1_na),
-        EU("cz-api.moj.io", false, R.array.iso3166_alpha3_eu, R.array.iso3166_alpha2_eu, R.array.iso639_1_eu);
-
-        private final String apiUrl;
-        private final boolean sandboxAvailable;
-        private final int iso3CountriesResId;
-        private final int iso2CountriesResId;
-        private final int iso2LanguagesResId;
-
-        Endpoint(String apiUrl, boolean sandboxAvailable, int iso3CountriesResId, int iso2CountriesResId, int iso2LanguagesResId) {
-            this.apiUrl = apiUrl;
-            this.sandboxAvailable = sandboxAvailable;
-            this.iso3CountriesResId = iso3CountriesResId;
-            this.iso2CountriesResId = iso2CountriesResId;
-            this.iso2LanguagesResId = iso2LanguagesResId;
-        }
-
-        public boolean isSandboxAvailable() {
-            return sandboxAvailable;
-        }
-
-        public String getApiUrl() {
-            return apiUrl;
-        }
-
-        public int getIso3CountriesResId() {
-            return iso3CountriesResId;
-        }
-
-        public int getIso2CountriesResId() {
-            return iso2CountriesResId;
-        }
-
-        public int getIso2LanguagesResId() {
-            return iso2LanguagesResId;
-        }
-    }
-
     //========================================================================
     // Endpoint setup
     //========================================================================
@@ -170,73 +127,12 @@ public class MojioClient {
      * @param clientLocale      The specified locale.
      */
     public synchronized void updateLocale(Locale clientLocale) {
-        /*
         if (_configuredLocale != null && clientLocale.equals(_configuredLocale)) {
             return;
         }
+
         Log.i(TAG, "Configuring SDK for locale '" + clientLocale + "'...");
-
-        Endpoint endpoint = null;
-        // first check the ISO3166 Alpha-3 country code
-        try {
-            String iso3Code = clientLocale.getISO3Country();
-            if (!TextUtils.isEmpty(iso3Code)) {
-                for (Endpoint e : Endpoint.values()) {
-                    Set<String> iso3Set = new HashSet<>(Arrays.asList(_ctx.getResources().getStringArray(e.getIso3CountriesResId())));
-                    if (iso3Set.contains(iso3Code)) {
-                        endpoint = e;
-                        break;
-                    }
-                }
-            }
-        } catch (final MissingResourceException e) {
-            Log.e(TAG, "Device is missing ISO 3166-1 alpha-3 country code resource", e);
-        }
-
-        // if no Alpha-3 code, check the Alpha-2 code
-        if (endpoint == null) {
-            Log.w(TAG, "Device did not report an ISO 3166-1 alpha-3 country code");
-            // fallback to checking alpha2 code
-            String iso2Code = clientLocale.getCountry();
-            if (!TextUtils.isEmpty(iso2Code)) {
-                // we're getting desperate, try the device's default country
-                iso2Code = clientLocale.getDisplayCountry();
-            }
-
-            if (!TextUtils.isEmpty(iso2Code)) {
-                for (Endpoint e : Endpoint.values()) {
-                    Set<String> iso2Set = new HashSet<>(Arrays.asList(_ctx.getResources().getStringArray(e.getIso2CountriesResId())));
-                    if (iso2Set.contains(iso2Code)) {
-                        endpoint = e;
-                        break;
-                    }
-                }
-            }
-        }
-
-        // If still no country code, use the device language
-        if (endpoint == null) {
-            Log.w(TAG, "Device did not report an ISO 3166-1 alpha-2 country code");
-            // fallback to checking language
-            String languageCode = clientLocale.getLanguage();
-            if (!TextUtils.isEmpty(languageCode)) {
-                for (Endpoint e : Endpoint.values()) {
-                    Set<String> languageSet = new HashSet<>(Arrays.asList(_ctx.getResources().getStringArray(e.getIso2LanguagesResId())));
-                    if (languageSet.contains(languageCode)) {
-                        endpoint = e;
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (endpoint == null) {
-            Log.w(TAG, "Could not determine device locale, defaulting to NA endpoints");
-            endpoint = Endpoint.NA;
-        }
-        */
-        // TODO for beta always use EU
-        Endpoint endpoint = Endpoint.EU;
+        Endpoint endpoint = Endpoint.fromLocale(_ctx, clientLocale);
         this.sandboxAvailable = endpoint.isSandboxAvailable();
         this.updateUrl(endpoint.getApiUrl());
         this._configuredLocale = clientLocale;

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/MojioClient.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/MojioClient.java
@@ -170,6 +170,7 @@ public class MojioClient {
      * @param clientLocale      The specified locale.
      */
     public synchronized void updateLocale(Locale clientLocale) {
+        /*
         if (_configuredLocale != null && clientLocale.equals(_configuredLocale)) {
             return;
         }
@@ -233,7 +234,9 @@ public class MojioClient {
             Log.w(TAG, "Could not determine device locale, defaulting to NA endpoints");
             endpoint = Endpoint.NA;
         }
-
+        */
+        // TODO for beta always use EU
+        Endpoint endpoint = Endpoint.EU;
         this.sandboxAvailable = endpoint.isSandboxAvailable();
         this.updateUrl(endpoint.getApiUrl());
         this._configuredLocale = clientLocale;

--- a/MojioSDK/mojiosdksrc/src/prod/java/io/moj/mobile/android/sdk/enums/Endpoint.java
+++ b/MojioSDK/mojiosdksrc/src/prod/java/io/moj/mobile/android/sdk/enums/Endpoint.java
@@ -1,0 +1,122 @@
+package io.moj.mobile.android.sdk.enums;
+
+import android.content.Context;
+import android.text.TextUtils;
+import android.util.Log;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.Set;
+
+import io.moj.mobile.android.sdk.R;
+
+/**
+ * An enumeration of different backend endpoints for the Mojio API.
+ * Created by skidson on 15-09-21.
+ */
+public enum Endpoint {
+
+    NA("api.moj.io", true, R.array.iso3166_alpha3_na, R.array.iso3166_alpha2_na, R.array.iso639_1_na),
+    EU("cz-api.moj.io", false, R.array.iso3166_alpha3_eu, R.array.iso3166_alpha2_eu, R.array.iso639_1_eu);
+
+    private static final String TAG = Endpoint.class.getSimpleName();
+
+    private final String apiUrl;
+    private final boolean sandboxAvailable;
+    private final int iso3CountriesResId;
+    private final int iso2CountriesResId;
+    private final int iso2LanguagesResId;
+
+    Endpoint(String apiUrl, boolean sandboxAvailable, int iso3CountriesResId, int iso2CountriesResId, int iso2LanguagesResId) {
+        this.apiUrl = apiUrl;
+        this.sandboxAvailable = sandboxAvailable;
+        this.iso3CountriesResId = iso3CountriesResId;
+        this.iso2CountriesResId = iso2CountriesResId;
+        this.iso2LanguagesResId = iso2LanguagesResId;
+    }
+
+    public boolean isSandboxAvailable() {
+        return sandboxAvailable;
+    }
+
+    public String getApiUrl() {
+        return apiUrl;
+    }
+
+    public int getIso3CountriesResId() {
+        return iso3CountriesResId;
+    }
+
+    public int getIso2CountriesResId() {
+        return iso2CountriesResId;
+    }
+
+    public int getIso2LanguagesResId() {
+            return iso2LanguagesResId;
+        }
+
+    public static Endpoint fromLocale(Context context, Locale locale) {
+        Endpoint endpoint = null;
+        // first check the ISO3166 Alpha-3 country code
+        try {
+            String iso3Code = locale.getISO3Country();
+            if (!TextUtils.isEmpty(iso3Code)) {
+                for (Endpoint e : Endpoint.values()) {
+                    Set<String> iso3Set = new HashSet<>(Arrays.asList(context.getResources().getStringArray(e.getIso3CountriesResId())));
+                    if (iso3Set.contains(iso3Code)) {
+                        endpoint = e;
+                        break;
+                    }
+                }
+            }
+        } catch (final MissingResourceException e) {
+            Log.e(TAG, "Device is missing ISO 3166-1 alpha-3 country code resource", e);
+        }
+
+        // if no Alpha-3 code, check the Alpha-2 code
+        if (endpoint == null) {
+            Log.w(TAG, "Device did not report an ISO 3166-1 alpha-3 country code");
+            // fallback to checking alpha2 code
+            String iso2Code = locale.getCountry();
+            if (!TextUtils.isEmpty(iso2Code)) {
+                // we're getting desperate, try the device's default country
+                iso2Code = locale.getDisplayCountry();
+            }
+
+            if (!TextUtils.isEmpty(iso2Code)) {
+                for (Endpoint e : Endpoint.values()) {
+                    Set<String> iso2Set = new HashSet<>(Arrays.asList(context.getResources().getStringArray(e.getIso2CountriesResId())));
+                    if (iso2Set.contains(iso2Code)) {
+                        endpoint = e;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // If still no country code, use the device language
+        if (endpoint == null) {
+            Log.w(TAG, "Device did not report an ISO 3166-1 alpha-2 country code");
+            // fallback to checking language
+            String languageCode = locale.getLanguage();
+            if (!TextUtils.isEmpty(languageCode)) {
+                for (Endpoint e : Endpoint.values()) {
+                    Set<String> languageSet = new HashSet<>(Arrays.asList(context.getResources().getStringArray(e.getIso2LanguagesResId())));
+                    if (languageSet.contains(languageCode)) {
+                        endpoint = e;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (endpoint == null) {
+            Log.w(TAG, "Could not determine device locale, defaulting to NA endpoints");
+            endpoint = Endpoint.NA;
+        }
+
+        return endpoint;
+    }
+}


### PR DESCRIPTION
- Added two flavors - beta and prod. Only difference between the two is the Endpoint class (src/beta/java/.../Endpoint.java vs. src/prod/java/.../Endpoint.java - fromLocale() always returns EU for beta.
- Note: this change will be followed by Cloak and Gauge updates to use the different flavours accordingly
- Updated to use Gradle 1.3.0 and Build Tools 21.1.2
