### PR TITLE
Added functionality for refreshing access token

### DIFF
--- a/MojioSDK/app/mojiosdksrc.iml
+++ b/MojioSDK/app/mojiosdksrc.iml
@@ -9,14 +9,15 @@
     <facet type="android" name="Android">
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="betaDebug" />
-        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
+        <option name="SELECTED_TEST_ARTIFACT" value="_unit_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleBetaDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileBetaDebugSources" />
-        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleBetaDebugAndroidTest" />
-        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileBetaDebugAndroidTestSources" />
+        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleBetaDebugUnitTest" />
+        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileBetaDebugUnitTestSources" />
         <afterSyncTasks>
-          <task>generateBetaDebugAndroidTestSources</task>
           <task>generateBetaDebugSources</task>
+          <task>mockableAndroidJar</task>
+          <task>prepareBetaDebugUnitTestDependencies</task>
         </afterSyncTasks>
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
@@ -29,7 +30,7 @@
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/classes/beta/debug" />
-    <output-test url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/classes/androidTest/beta/debug" />
+    <output-test url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/classes/test/beta/debug" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../mojiosdksrc">
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/r/beta/debug" isTestSource="false" generated="true" />
@@ -45,12 +46,13 @@
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/betaDebug/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/betaDebug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/betaDebug/rs" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/r/androidTest/beta/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/aidl/androidTest/beta/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/buildConfig/androidTest/beta/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/source/rs/androidTest/beta/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/res/rs/androidTest/beta/debug" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/generated/res/resValues/androidTest/beta/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testBetaDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testBetaDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testBetaDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testBetaDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testBetaDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testBetaDebug/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testBetaDebug/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/beta/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/beta/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/beta/assets" type="java-resource" />
@@ -58,13 +60,13 @@
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/beta/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/beta/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/beta/rs" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTestBeta/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTestBeta/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTestBeta/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTestBeta/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTestBeta/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTestBeta/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTestBeta/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testBeta/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testBeta/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testBeta/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testBeta/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testBeta/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testBeta/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testBeta/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/debug/assets" type="java-resource" />
@@ -72,6 +74,13 @@
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/debug/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/debug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/debug/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testDebug/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/testDebug/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/main/assets" type="java-resource" />
@@ -79,13 +88,13 @@
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/main/rs" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/test/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../mojiosdksrc/src/test/rs" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/classes" />
@@ -107,17 +116,21 @@
       <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/reports" />
+      <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/test-results" />
       <excludeFolder url="file://$MODULE_DIR$/../mojiosdksrc/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" exported="" name="appcompat-v7-21.0.3" level="project" />
     <orderEntry type="library" exported="" name="signalr-client-sdk-android-release-1.0" level="project" />
-    <orderEntry type="library" exported="" name="support-annotations-21.0.3" level="project" />
     <orderEntry type="library" exported="" name="gson-2.2.4" level="project" />
+    <orderEntry type="library" exported="" name="support-annotations-21.0.3" level="project" />
     <orderEntry type="library" exported="" name="support-v4-21.0.3" level="project" />
     <orderEntry type="library" exported="" name="joda-time-2.5" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="hamcrest-core-1.3" level="project" />
     <orderEntry type="library" exported="" name="library-1.0.6" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="junit-4.12" level="project" />
     <orderEntry type="module" module-name="libraries" exported="" />
   </component>
 </module>

--- a/MojioSDK/libraries/libraries.iml
+++ b/MojioSDK/libraries/libraries.iml
@@ -9,14 +9,15 @@
     <facet type="android" name="Android">
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="debug" />
-        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
+        <option name="SELECTED_TEST_ARTIFACT" value="_unit_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
-        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugAndroidTest" />
-        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileDebugAndroidTestSources" />
+        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugUnitTest" />
+        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileDebugUnitTestSources" />
         <afterSyncTasks>
-          <task>generateDebugAndroidTestSources</task>
           <task>generateDebugSources</task>
+          <task>mockableAndroidJar</task>
+          <task>prepareDebugUnitTestDependencies</task>
         </afterSyncTasks>
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
@@ -29,7 +30,7 @@
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
-    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/androidTest/debug" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/debug" isTestSource="false" generated="true" />
@@ -38,12 +39,6 @@
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
@@ -51,6 +46,13 @@
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
@@ -58,13 +60,13 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
@@ -87,6 +89,8 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/reports" />
+      <excludeFolder url="file://$MODULE_DIR$/build/test-results" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />

--- a/MojioSDK/mojiosdksrc/build.gradle
+++ b/MojioSDK/mojiosdksrc/build.gradle
@@ -9,15 +9,22 @@ android {
         versionCode 7
         versionName "1.0.5"
     }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
     productFlavors {
         beta { }
         prod { }
+    }
+
+    testOptions {
+        // lets us not explode on OS calls (e.g. Log.e())
+        unitTests.returnDefaultValues = true
     }
 }
 
@@ -35,4 +42,6 @@ dependencies {
     compile 'joda-time:joda-time:2.5'
     compile project(':libraries')
     compile 'client.signalr.aspnet.microsoft.signalr_client_sdk_android:signalr-client-sdk-android-release:1.0@aar'
+
+    testCompile 'junit:junit:4.12'
 }

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/DataStorageHelper.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/DataStorageHelper.java
@@ -56,7 +56,9 @@ public class DataStorageHelper {
             Log.w(TAG, PREF_ACCESS_TOKEN_EXPIRES + " was of an unexpected type", e);
             expirationTimestamp = 0;
         }
-        return (expirationTimestamp - System.currentTimeMillis()) < TOKEN_REFRESH_MS;
+        long msToExpiration = expirationTimestamp - System.currentTimeMillis();
+        Log.v(TAG, "Access token expires in: " + msToExpiration + "ms");
+        return msToExpiration < TOKEN_REFRESH_MS;
     }
 
     public boolean isUserToken() {

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/DataStorageHelper.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/DataStorageHelper.java
@@ -31,9 +31,11 @@ public class DataStorageHelper {
 
     @SuppressLint("CommitPrefEdits")
     public void setAccessToken(String accessToken, String expirationTime, boolean isUserToken) {
+        long expirationTimestamp = TimeFormatHelpers.fromServerFormatted(expirationTime).getMillis();
+
         Editor sharedPreferences = mContext.getSharedPreferences(SHARED_PREF_ID, Context.MODE_PRIVATE).edit();
         sharedPreferences.putString(PREF_ACCESS_TOKEN, accessToken);
-        sharedPreferences.putString(PREF_ACCESS_TOKEN_EXPIRES, expirationTime);
+        sharedPreferences.putLong(PREF_ACCESS_TOKEN_EXPIRES, expirationTimestamp);
         sharedPreferences.putBoolean(PREF_ACCESS_TOKEN_IS_USER, isUserToken);
         sharedPreferences.commit();
     }
@@ -54,7 +56,9 @@ public class DataStorageHelper {
             Log.w(TAG, PREF_ACCESS_TOKEN_EXPIRES + " was of an unexpected type", e);
             expirationTimestamp = 0;
         }
-        return (expirationTimestamp - System.currentTimeMillis()) < TOKEN_REFRESH_MS;
+        long msToExpiration = expirationTimestamp - System.currentTimeMillis();
+        Log.d(TAG, "Access token expires in: " + msToExpiration + "ms");
+        return msToExpiration < TOKEN_REFRESH_MS;
     }
 
     public boolean isUserToken() {

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/DataStorageHelper.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/DataStorageHelper.java
@@ -56,9 +56,7 @@ public class DataStorageHelper {
             Log.w(TAG, PREF_ACCESS_TOKEN_EXPIRES + " was of an unexpected type", e);
             expirationTimestamp = 0;
         }
-        long msToExpiration = expirationTimestamp - System.currentTimeMillis();
-        Log.d(TAG, "Access token expires in: " + msToExpiration + "ms");
-        return msToExpiration < TOKEN_REFRESH_MS;
+        return (expirationTimestamp - System.currentTimeMillis()) < TOKEN_REFRESH_MS;
     }
 
     public boolean isUserToken() {

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/TimeFormatHelpers.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/TimeFormatHelpers.java
@@ -7,11 +7,12 @@ import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.PeriodFormatter;
 import org.joda.time.format.PeriodFormatterBuilder;
 
+import java.text.SimpleDateFormat;
+
 /**
  * Created by ssawchenko on 15-01-27.
  */
 public class TimeFormatHelpers {
-
     private static DateTimeFormatter FORMATTER_FROM_SERVER = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ");
     private static DateTimeFormatter FORMATTER_VERBOSE_DATE = DateTimeFormat.forPattern("MMMM dd, YYYY hh:mma"); // Feb 1st, 2015 5:00pm
     private static DateTimeFormatter FORMATTER_TIME_CRITERIA = DateTimeFormat.forPattern("YYYY.MM.dd");
@@ -33,20 +34,15 @@ public class TimeFormatHelpers {
     private static String ERROR_RESPONSE = "??";
 
     public static DateTime fromServerFormatted(String datetime) {
-        try {
-            return DateTime.parse(datetime, FORMATTER_FROM_SERVER);
-        }
-        catch (Exception e) {
-            return null;
-        }
+        return DateTime.parse(datetime, FORMATTER_FROM_SERVER);
     }
+
     public static String getVerboseDateTime(String datetime) {
         // Feb 1st, 2015 5:00pm
         try {
             DateTime dt = DateTime.parse(datetime, FORMATTER_FROM_SERVER);
             return getVerboseDateTime(dt);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             return ERROR_RESPONSE;
         }
     }
@@ -55,8 +51,7 @@ public class TimeFormatHelpers {
         // Feb 1st, 2015 5:00pm
         try {
             return FORMATTER_VERBOSE_DATE.print(dt);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             return ERROR_RESPONSE;
         }
     }

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/TimeFormatHelpers.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/TimeFormatHelpers.java
@@ -1,5 +1,7 @@
 package io.moj.mobile.android.sdk;
 
+import android.util.Log;
+
 import org.joda.time.DateTime;
 import org.joda.time.Period;
 import org.joda.time.format.DateTimeFormat;
@@ -13,9 +15,12 @@ import java.text.SimpleDateFormat;
  * Created by ssawchenko on 15-01-27.
  */
 public class TimeFormatHelpers {
-    private static DateTimeFormatter FORMATTER_FROM_SERVER = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ");
-    private static DateTimeFormatter FORMATTER_VERBOSE_DATE = DateTimeFormat.forPattern("MMMM dd, YYYY hh:mma"); // Feb 1st, 2015 5:00pm
-    private static DateTimeFormatter FORMATTER_TIME_CRITERIA = DateTimeFormat.forPattern("YYYY.MM.dd");
+    private static final String TAG = TimeFormatHelpers.class.getSimpleName();
+
+    private static final String FORMAT_FROM_SERVER = "yyyy-MM-dd'T'HH:mm:ssZ";
+    private static DateTimeFormatter FORMATTER_FROM_SERVER = DateTimeFormat.forPattern(FORMAT_FROM_SERVER).withZoneUTC();
+    private static DateTimeFormatter FORMATTER_VERBOSE_DATE = DateTimeFormat.forPattern("MMMM dd, YYYY hh:mma").withZoneUTC();
+    private static DateTimeFormatter FORMATTER_TIME_CRITERIA = DateTimeFormat.forPattern("YYYY.MM.dd").withZoneUTC();
 
     private static PeriodFormatter FORMATTER_FOR_ELAPSED_TIME = new PeriodFormatterBuilder()
             .printZeroAlways()
@@ -33,8 +38,25 @@ public class TimeFormatHelpers {
 
     private static String ERROR_RESPONSE = "??";
 
-    public static DateTime fromServerFormatted(String datetime) {
-        return DateTime.parse(datetime, FORMATTER_FROM_SERVER);
+    /**
+     * Returns a UTC {@link DateTime} given a UTC date from the server. Note that since the server sends a
+     * variable amount of milliseconds we always chop them off for parsing.
+     * @param date
+     * @return a {@link DateTime} instance for the given date or null if parsing failed.
+     */
+    public static DateTime fromServerFormatted(String date) {
+        int endIndex = date.lastIndexOf(".");
+        if (endIndex > 0) {
+            date = date.substring(0, endIndex) + "Z";
+        }
+
+        DateTime dateTime = null;
+        try {
+            dateTime = DateTime.parse(date, FORMATTER_FROM_SERVER);
+        } catch (IllegalArgumentException e) {
+            Log.e(TAG, "Server sent an invalid date format: " + date, e);
+        }
+        return dateTime;
     }
 
     public static String getVerboseDateTime(String datetime) {

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/TimeFormatHelpers.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/TimeFormatHelpers.java
@@ -13,7 +13,7 @@ import java.text.SimpleDateFormat;
  * Created by ssawchenko on 15-01-27.
  */
 public class TimeFormatHelpers {
-    private static DateTimeFormatter FORMATTER_FROM_SERVER = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ");
+    private static DateTimeFormatter FORMATTER_FROM_SERVER = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ");
     private static DateTimeFormatter FORMATTER_VERBOSE_DATE = DateTimeFormat.forPattern("MMMM dd, YYYY hh:mma"); // Feb 1st, 2015 5:00pm
     private static DateTimeFormatter FORMATTER_TIME_CRITERIA = DateTimeFormat.forPattern("YYYY.MM.dd");
 

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioImageRequest.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioImageRequest.java
@@ -7,6 +7,7 @@ import android.util.Log;
 import com.android.volley.AuthFailureError;
 import com.android.volley.Response;
 import com.android.volley.toolbox.ImageRequest;
+
 import io.moj.mobile.android.sdk.DataStorageHelper;
 
 import java.util.HashMap;
@@ -15,7 +16,7 @@ import java.util.Map;
 /**
  * Created by jian on 24/02/2015.
  */
-public class MojioImageRequest extends ImageRequest{
+public class MojioImageRequest extends ImageRequest {
 
     private Context mAppContext;
     private String mUrl;
@@ -54,10 +55,10 @@ public class MojioImageRequest extends ImageRequest{
 
     private void commonInit(Context appContext,
                             String url,
-                       Response.Listener<Bitmap> listener,
-                       int maxWidth, int maxHeight,
-                       Bitmap.Config decodeConfig,
-                       Response.ErrorListener errorListener){
+                            Response.Listener<Bitmap> listener,
+                            int maxWidth, int maxHeight,
+                            Bitmap.Config decodeConfig,
+                            Response.ErrorListener errorListener) {
 
         this.mAppContext = appContext;
         this.mUrl = url;
@@ -77,9 +78,6 @@ public class MojioImageRequest extends ImageRequest{
         // Check for auth token
         // Start with user auth, if that does not exist, check for app auth
         String mojioAuth = oauth.getAccessToken();
-        if (mojioAuth == null) {
-            mojioAuth = oauth.getAppToken();
-        }
         if (mojioAuth != null) {
             headers.put("MojioAPIToken", mojioAuth);
         }

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioImageRequest.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioImageRequest.java
@@ -76,9 +76,9 @@ public class MojioImageRequest extends ImageRequest{
 
         // Check for auth token
         // Start with user auth, if that does not exist, check for app auth
-        String mojioAuth = oauth.GetAccessToken();
+        String mojioAuth = oauth.getAccessToken();
         if (mojioAuth == null) {
-            mojioAuth = oauth.GetAppToken();
+            mojioAuth = oauth.getAppToken();
         }
         if (mojioAuth != null) {
             headers.put("MojioAPIToken", mojioAuth);

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioRequest.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioRequest.java
@@ -13,14 +13,11 @@ import com.android.volley.Request;
 import com.android.volley.Response;
 import com.android.volley.toolbox.HttpHeaderParser;
 import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
 
 import org.apache.http.HttpStatus;
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.ByteArrayOutputStream;
-import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -30,13 +27,13 @@ import io.moj.mobile.android.sdk.DataStorageHelper;
 /**
  * Writen by Shayla Sawchenko
  * Based on GsonVolleyRequest by Ognyan Bankov
- *
+ * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,6 +46,7 @@ import io.moj.mobile.android.sdk.DataStorageHelper;
  */
 public class MojioRequest<T> extends Request<T> {
 
+    private static final String TAG = MojioRequest.class.getSimpleName();
     private static final String PROTOCOL_CHARSET = "utf-8";
     private static final String PROTOCOL_CONTENT_TYPE = String.format("application/json; charset=%s", PROTOCOL_CHARSET);
 
@@ -143,9 +141,6 @@ public class MojioRequest<T> extends Request<T> {
         this.listener = listener;
         this.mMethod = method;
         mGson = new Gson();
-        // Error listener?
-
-        Log.i("MOJIO", "Creating request for " + this.mUrl);
     }
 
     @Override
@@ -157,23 +152,21 @@ public class MojioRequest<T> extends Request<T> {
         // Check for auth token
         // Start with user auth, if that does not exist, check for app auth
         String mojioAuth = oauth.getAccessToken();
-        if (mojioAuth == null) {
-            mojioAuth = oauth.getAppToken();
-        }
         if (mojioAuth != null) {
             headers.put("MojioAPIToken", mojioAuth);
         }
-        if(imageByteArray != null){
+
+        if (imageByteArray != null) {
             String body = String.format("\"%s\"", this.contentBody);
             headers.put("Content-Type", "application/json; charset=utf-8");
-            headers.put("Content-Length",String.valueOf(body.length()));
+            headers.put("Content-Length", String.valueOf(body.length()));
         }
 
         // Client locale header
         headers.put("Accept-Language", getLocaleString(this.mAppContext));
 
         // TODO may want to init MojioClient WITH access token. This would make the app responsible for storing token data.
-        Log.i("MOJIO", "Adding headers: " + headers.toString());
+        Log.i(TAG, "Adding headers: " + headers.toString());
         return headers;
     }
 
@@ -187,15 +180,12 @@ public class MojioRequest<T> extends Request<T> {
         // If content body given, use it.
         if (this.contentBody == null) {
             return super.getBody();
-
         } else {
             String body = this.contentBody;
-
             if (!body.startsWith("{")) {
                 body = String.format("\"%s\"", this.contentBody); // Add quotes around body
             }
-
-            Log.i("MOJIO", "Adding content body: " + body);
+            Log.i(TAG, "Adding content body: " + body);
             return body.getBytes();
         }
     }
@@ -221,28 +211,15 @@ public class MojioRequest<T> extends Request<T> {
             T result = null;
 
             String responseString = new String(response.data, HttpHeaderParser.parseCharset(response.headers));
-            Log.i("MOJIO", "Response for " + mUrl);
-            Log.i("MOJIO", responseString);
-
+            Log.i(TAG, "Response [" + VolleyHelper.parseMethodString(getMethod()) + " " + mUrl + "]: " + responseString);
             if (responseString.isEmpty()) {
                 // Body was empty, no need to parse.
                 return Response.success(result, HttpHeaderParser.parseCacheHeaders(response));
             }
 
-            // Else attempt to parse into the expected class.
-
-            /*
-            if ((this.mMethod == Method.PUT)
-                    || (this.mMethod == Method.DELETE)
-                    || (this.mMethod == Method.POST)) {
-                // Response body will be empty, no need to parse.
-                return Response.success(result, HttpHeaderParser.parseCacheHeaders(response));
-            }
-            */
-
             // If we want just a String, simply return the response.data casted as such.
             if (this.clazz == String.class) {
-                result = (T)responseString;
+                result = (T) responseString;
                 return Response.success(result, HttpHeaderParser.parseCacheHeaders(response));
             }
 
@@ -257,22 +234,8 @@ public class MojioRequest<T> extends Request<T> {
             }
 
             return Response.success(result, HttpHeaderParser.parseCacheHeaders(response));
-
-        } catch (UnsupportedEncodingException e) {
-            Log.e("MOJIO", "MojioRequest UnsupportedEncodingException error");
-            return Response.error(new ParseError(e));
-
-        } catch (JsonSyntaxException e) {
-            Log.e("MOJIO", "MojioRequest JsonSyntaxException error" + e.getMessage());
-            return Response.error(new ParseError(e));
-
-        } catch (JSONException e) {
-            Log.e("MOJIO", "MojioRequest JSONException error: " + e.getMessage());
-            return Response.error(new ParseError(e));
-
-        }
-        catch (com.google.gson.JsonParseException e) {
-            Log.e("MOJIO", "MojioRequest JSONException error: " + e.getMessage());
+        } catch (Exception e) {
+            Log.e(TAG, "Error parsing network response", e);
             return Response.error(new ParseError(e));
         }
     }
@@ -290,5 +253,6 @@ public class MojioRequest<T> extends Request<T> {
         else
             return String.format("%s-%s", language, country);
     }
+
 }
 

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioRequest.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioRequest.java
@@ -156,9 +156,9 @@ public class MojioRequest<T> extends Request<T> {
 
         // Check for auth token
         // Start with user auth, if that does not exist, check for app auth
-        String mojioAuth = oauth.GetAccessToken();
+        String mojioAuth = oauth.getAccessToken();
         if (mojioAuth == null) {
-            mojioAuth = oauth.GetAppToken();
+            mojioAuth = oauth.getAppToken();
         }
         if (mojioAuth != null) {
             headers.put("MojioAPIToken", mojioAuth);

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/OAuthLoginActivity.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/OAuthLoginActivity.java
@@ -47,7 +47,7 @@ public class OAuthLoginActivity extends Activity {
 
                     // Return in bundle, but also stored in shared prefs
                     Bundle bundle = new Bundle();
-                    bundle.putString("accessToken", _oauthHelper.GetAccessToken());
+                    bundle.putString("accessToken", _oauthHelper.getAccessToken());
 
                     Intent resultIntent = new Intent();
                     resultIntent.putExtras(bundle);

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/OAuthLoginActivity.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/OAuthLoginActivity.java
@@ -42,8 +42,7 @@ public class OAuthLoginActivity extends Activity {
                     String [] accessToken = parameters[0].split("=");
                     String [] expiresIn = parameters[2].split("=");
 
-                    _oauthHelper.SetAccessToken(accessToken[1]);
-                    _oauthHelper.SetAccessExpireTime(expiresIn[1]);
+                    _oauthHelper.setAccessToken(accessToken[1], expiresIn[1]);
 
                     // Return in bundle, but also stored in shared prefs
                     Bundle bundle = new Bundle();

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/VolleyHelper.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/VolleyHelper.java
@@ -22,7 +22,6 @@ public class VolleyHelper {
     private final int SOCKET_TIMEOUT_MS = 5000;
 
     private RequestQueue _requestQueue;
-    private CookieManager _cookieManager;
     private Context _ctx;
 
     private DefaultRetryPolicy _defaultRetryPolicy = new DefaultRetryPolicy(
@@ -41,11 +40,10 @@ public class VolleyHelper {
         // Lazy initialize the request queue, the queue instance will be
         // created when it is accessed for the first time
         if (_requestQueue == null) {
-
             // Set default cookie manager
-            _cookieManager = new CookieManager();
-            _cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
-            CookieHandler.setDefault(_cookieManager);
+            CookieManager cookieManager = new CookieManager();
+            cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
+            CookieHandler.setDefault(cookieManager);
 
             // newRequestQueue uses volley's BasicNetwork, which uses an underlying HttpURLConnection object
             // SHOULD automatically query the CookieManager
@@ -70,7 +68,7 @@ public class VolleyHelper {
         // set the default tag if tag is empty
         req.setTag(tag == null || TextUtils.isEmpty(tag) ? TAG : tag);
         req.setRetryPolicy(_defaultRetryPolicy);
-        Log.i(TAG, String.format("VolleyHelper adding request to queue: %s", req.getUrl()));
+        Log.i(TAG, "Request [" + parseMethodString(req.getMethod()) + ": " + req.getUrl() + "]");
 
         getRequestQueue().add(req);
     }
@@ -80,7 +78,7 @@ public class VolleyHelper {
      *
      * @param req
      */
-    public <T> void addToRequestQueue(Request<T> req) {
+    public <T> void addToRequestQueue(MojioRequest<T> req) {
         // set the default tag if tag is empty
         addToRequestQueue(req, null);
     }
@@ -94,6 +92,34 @@ public class VolleyHelper {
     public void cancelPendingRequests(Object tag) {
         if (_requestQueue != null) {
             _requestQueue.cancelAll(tag);
+        }
+    }
+
+    /**
+     * Returns the string method name given a Volley integer {@link com.android.volley.Request.Method}.
+     * @param method
+     * @return
+     */
+    public static String parseMethodString(int method) {
+        switch (method) {
+            case Request.Method.GET:
+                return "GET";
+            case Request.Method.POST:
+                return "POST";
+            case Request.Method.PUT:
+                return "PUT";
+            case Request.Method.DELETE:
+                return "DELETE";
+            case Request.Method.HEAD:
+                return "HEAD";
+            case Request.Method.OPTIONS:
+                return "OPTIONS";
+            case Request.Method.TRACE:
+                return "TRACE";
+            case Request.Method.PATCH:
+                return "PATCH";
+            default:
+                return null;
         }
     }
 }

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/VolleyHelper.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/VolleyHelper.java
@@ -63,7 +63,6 @@ public class VolleyHelper {
      * @param tag
      */
     public <T> void addToRequestQueue(Request<T> req, String tag) {
-
         if (_requestQueue == null) {
             getRequestQueue();
         }

--- a/MojioSDK/mojiosdksrc/src/test/java/io/moj/mobile/android/sdk/units/TimeFormatHelpersTest.java
+++ b/MojioSDK/mojiosdksrc/src/test/java/io/moj/mobile/android/sdk/units/TimeFormatHelpersTest.java
@@ -1,0 +1,42 @@
+package io.moj.mobile.android.sdk.units;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import io.moj.mobile.android.sdk.TimeFormatHelpers;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNull;
+
+/**
+ * Created by skidson on 15-09-23.
+ */
+public class TimeFormatHelpersTest {
+
+    @Test
+    public void testFromServerFormatted_withMs() {
+        assetFromServerFormatted("2015-09-21T22:36:45.2487052Z", 2015, 9, 21, 22, 36, 45);
+    }
+
+    @Test
+    public void testFromServerFormatted_withoutMs() {
+        assetFromServerFormatted("2016-07-02T01:27:11Z", 2016, 7, 2, 1, 27, 11);
+    }
+
+    @Test
+    public void testFromServerFormatted_invalid() {
+        assertNull(TimeFormatHelpers.fromServerFormatted("invalid"));
+    }
+
+    private static void assetFromServerFormatted(String serverDate, int expectedYears,
+        int expectedMonths, int expectedDays, int expectedHours, int expectedMinutes, int expectedSeconds) {
+        DateTime dateTime = TimeFormatHelpers.fromServerFormatted(serverDate);
+        assertEquals("Failed to parse years for " + serverDate, expectedYears, dateTime.getYear());
+        assertEquals("Failed to parse months for " + serverDate, expectedMonths, dateTime.getMonthOfYear());
+        assertEquals("Failed to parse days for " + serverDate, expectedDays, dateTime.getDayOfMonth());
+        assertEquals("Failed to parse hours for " + serverDate, expectedHours, dateTime.getHourOfDay());
+        assertEquals("Failed to parse minutes for " + serverDate, expectedMinutes, dateTime.getMinuteOfHour());
+        assertEquals("Failed to parse seconds for " + serverDate, expectedSeconds, dateTime.getSecondOfMinute());
+    }
+
+}


### PR DESCRIPTION
A general overview:
- When any API request is made, the access token is checked to see if it will expire in the next minute - if so, a parallel request is queued to refresh it (with locking so other async requests don't all spam the refresh API)
- Will follow up with app updates to always check MojioClient.isUserLoggedIn() on startup (e.g. Gauge only checked if we had a cached User). This method now validates the access token is not expired.

Other changes:
- Simplified storage to only have one access token at a time (with a flag if it is a valid user token or not)
- Made SDK requests also log the method (GET, POST, etc) for each URL
