### PR TITLE
Changes to support API paging

### DIFF
--- a/MojioSDK/app/mojiosdksrc.iml
+++ b/MojioSDK/app/mojiosdksrc.iml
@@ -123,9 +123,9 @@
     <orderEntry type="library" exported="" name="gson-2.3.1" level="project" />
     <orderEntry type="library" exported="" name="appcompat-v7-21.0.3" level="project" />
     <orderEntry type="library" exported="" name="signalr-client-sdk-android-release-1.0" level="project" />
-    <orderEntry type="library" exported="" name="library-1.0.19" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-21.0.3" level="project" />
     <orderEntry type="library" exported="" name="okhttp-2.5.0" level="project" />
+    <orderEntry type="library" exported="" name="library-1.0.19" level="project" />
     <orderEntry type="library" exported="" name="support-v4-21.0.3" level="project" />
     <orderEntry type="library" exported="" name="okio-1.6.0" level="project" />
     <orderEntry type="library" exported="" name="joda-time-2.5" level="project" />

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/MojioClient.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/MojioClient.java
@@ -115,8 +115,8 @@ public class MojioClient {
     }
 
     public static abstract class ResponseListener<T> implements Response.Listener<MojioResponse<T>>, Response.ErrorListener {
-        abstract void onSuccess(MojioResponse<T> result);
-        abstract void onFailure(ResponseError error);
+        public abstract void onSuccess(MojioResponse<T> result);
+        public abstract void onFailure(ResponseError error);
 
         @Override
         public void onResponse(MojioResponse<T> response) {

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/MojioClient.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/MojioClient.java
@@ -14,6 +14,7 @@ import com.android.volley.TimeoutError;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.HttpHeaderParser;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 
 import java.io.UnsupportedEncodingException;

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/MojioClient.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/MojioClient.java
@@ -14,7 +14,6 @@ import com.android.volley.TimeoutError;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.HttpHeaderParser;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 
 import java.io.UnsupportedEncodingException;
@@ -26,8 +25,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.moj.mobile.android.sdk.enums.Endpoint;
-import io.moj.mobile.android.sdk.models.User;
 import io.moj.mobile.android.sdk.models.Token;
+import io.moj.mobile.android.sdk.models.User;
 import io.moj.mobile.android.sdk.models.observers.Observer;
 import io.moj.mobile.android.sdk.networking.MojioImageRequest;
 import io.moj.mobile.android.sdk.networking.MojioRequest;

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/MojioClient.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/MojioClient.java
@@ -716,6 +716,10 @@ public class MojioClient {
         requestHelper.cancelPendingRequests(REQUEST_TAG);
     }
 
+    public static Gson getGson() {
+        return GSON;
+    }
+
     private static void reportVolleyError(final VolleyError error, ResponseListener listener) {
         // Attempt to parse response errors
         try {

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioImageRequest.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioImageRequest.java
@@ -9,6 +9,7 @@ import com.android.volley.Response;
 import com.android.volley.toolbox.ImageRequest;
 
 import io.moj.mobile.android.sdk.DataStorageHelper;
+import io.moj.mobile.android.sdk.MojioClient;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,9 +43,13 @@ public class MojioImageRequest extends ImageRequest {
                              String url,
                              int maxWidth, int maxHeight,
                              Bitmap.Config decodeConfig,
-                             Response.Listener<Bitmap> listener,
-                             Response.ErrorListener errorListener) {
-        super(url, listener, maxWidth, maxHeight, decodeConfig, errorListener);
+                             final MojioClient.ResponseListener<Bitmap> listener) {
+        super(url, new Response.Listener<Bitmap>() {
+            @Override
+            public void onResponse(Bitmap response) {
+                listener.onResponse(new MojioResponse<>(response));
+            }
+        }, maxWidth, maxHeight, decodeConfig, listener);
         // TODO we could avoid holding context by just passing headers in here instead
         this.context = context;
     }

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioImageRequest.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioImageRequest.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.util.Log;
 
 import com.android.volley.AuthFailureError;
+import com.android.volley.NetworkResponse;
 import com.android.volley.Response;
 import com.android.volley.toolbox.ImageRequest;
 

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioRequest.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioRequest.java
@@ -13,16 +13,18 @@ import com.android.volley.Request;
 import com.android.volley.Response;
 import com.android.volley.toolbox.HttpHeaderParser;
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
-import org.apache.http.HttpStatus;
 import org.json.JSONObject;
 
 import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
 import io.moj.mobile.android.sdk.DataStorageHelper;
+import io.moj.mobile.android.sdk.MojioClient;
 
 /**
  * Writen by Shayla Sawchenko
@@ -44,7 +46,7 @@ import io.moj.mobile.android.sdk.DataStorageHelper;
 /**
  * Volley adapter for JSON requests with POST method that will be parsed into Java objects by Gson.
  */
-public class MojioRequest<T> extends Request<T> {
+public class MojioRequest<T> extends Request<MojioResponse<T>> {
 
     private static final String TAG = MojioRequest.class.getSimpleName();
     private static final String PROTOCOL_CHARSET = "utf-8";
@@ -55,9 +57,8 @@ public class MojioRequest<T> extends Request<T> {
     private Class<T> clazz;
     private Map<String, String> params;
     private String contentBody;
-    private byte[] imageByteArray;
-    private Response.Listener<T> listener;
-    private String mUrl;
+    private MojioClient.ResponseListener<T> listener;
+    private boolean blobContent = false;
 
     /**
      * Make a GET request and return a parsed object from JSON.
@@ -69,10 +70,9 @@ public class MojioRequest<T> extends Request<T> {
                         int method,
                         String url,
                         Class<T> clazz,
-                        Response.Listener<T> listener,
-                        Response.ErrorListener errorListener) {
-        super(method, url, errorListener);
-        commonInit(appContext, url, clazz, listener);
+                        MojioClient.ResponseListener<T> listener) {
+        super(method, url, listener);
+        commonInit(appContext, clazz, null, null, listener);
     }
 
     /**
@@ -86,11 +86,9 @@ public class MojioRequest<T> extends Request<T> {
                         String url,
                         Class<T> clazz,
                         Map<String, String> params,
-                        Response.Listener<T> listener,
-                        Response.ErrorListener errorListener) {
-        super(method, url, errorListener);
-        commonInit(appContext, url, clazz, listener);
-        this.params = params;
+                        MojioClient.ResponseListener<T> listener) {
+        super(method, url, listener);
+        commonInit(appContext, clazz, params, null, listener);
     }
 
     public MojioRequest(Context appContext,
@@ -98,11 +96,9 @@ public class MojioRequest<T> extends Request<T> {
                         String url,
                         Class<T> clazz,
                         String contentBody,
-                        Response.Listener<T> listener,
-                        Response.ErrorListener errorListener) {
-        super(method, url, errorListener);
-        commonInit(appContext, url, clazz, listener);
-        this.contentBody = contentBody;
+                        MojioClient.ResponseListener<T> listener) {
+        super(method, url, listener);
+        commonInit(appContext, clazz, params, contentBody, listener);
     }
 
     public MojioRequest(Context appContext,
@@ -110,27 +106,26 @@ public class MojioRequest<T> extends Request<T> {
                         String url,
                         Class<T> clazz,
                         Bitmap contentBody,
-                        Response.Listener<T> listener,
-                        Response.ErrorListener errorListener) {
-        super(method, url, errorListener);
-        commonInit(appContext, url, clazz, listener);
+                        MojioClient.ResponseListener<T> listener) {
+        super(method, url, listener);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         contentBody.compress(Bitmap.CompressFormat.PNG, 100, baos);
-        byte[] b = baos.toByteArray();
-        String imageEncoded = Base64.encodeToString(b, Base64.DEFAULT);
-        this.imageByteArray = b;
-        this.contentBody = imageEncoded;
+        String imageEncoded = Base64.encodeToString(baos.toByteArray(), Base64.DEFAULT);
+        this.blobContent = true;
+        commonInit(appContext, clazz, null, imageEncoded, listener);
     }
 
     private void commonInit(Context appContext,
-                            String url,
                             Class<T> clazz,
-                            Response.Listener<T> listener) {
-        this.mUrl = url;
+                            Map<String, String> params,
+                            String contentBody,
+                            MojioClient.ResponseListener<T> listener) {
         // TODO we could avoid holding context by passing headers and locale here instead
         this.mAppContext = appContext;
         this.clazz = clazz;
+        this.params = params;
+        this.contentBody = contentBody;
         this.listener = listener;
     }
 
@@ -144,7 +139,8 @@ public class MojioRequest<T> extends Request<T> {
             headers.put("MojioAPIToken", mojioAuth);
         }
 
-        if (imageByteArray != null) {
+        // TODO would it hurt to always specify these headers if contentBody isn't empty?
+        if (blobContent) {
             String body = String.format("\"%s\"", this.contentBody);
             headers.put("Content-Type", PROTOCOL_CONTENT_TYPE);
             headers.put("Content-Length", String.valueOf(body.length()));
@@ -182,41 +178,38 @@ public class MojioRequest<T> extends Request<T> {
     }
 
     @Override
-    protected void deliverResponse(T response) {
+    protected void deliverResponse(MojioResponse<T> response) {
         listener.onResponse(response);
     }
 
     @Override
-    protected Response<T> parseNetworkResponse(NetworkResponse response) {
+    protected Response<MojioResponse<T>> parseNetworkResponse(NetworkResponse response) {
         try {
-            T result = null;
-
+            MojioResponse<T> result = null;
             String responseString = new String(response.data, HttpHeaderParser.parseCharset(response.headers));
-            Log.v(TAG, "Response [" + VolleyHelper.parseMethodString(getMethod()) + " " + mUrl + "]: " + responseString.replace("\n", ""));
+            Log.v(TAG, "Response [" + VolleyHelper.parseMethodString(getMethod()) + " " + getUrl() + "]: " + responseString.replace("\n", ""));
+
             if (responseString.isEmpty()) {
+                result = new MojioResponse<>();
                 // Body was empty, no need to parse.
-                return Response.success(result, HttpHeaderParser.parseCacheHeaders(response));
-            }
-
-            // If we want just a String, simply return the response.data casted as such.
-            if (this.clazz == String.class) {
-                result = (T) responseString;
-                return Response.success(result, HttpHeaderParser.parseCacheHeaders(response));
-            }
-
-            // TODO this is where we have to start handling pagination (e.g. add a page value to all
-            // responses and allow app to easily request next page, such as on scroll)
-
-            // this handles responses that wrap the data and have a Data element
-            JSONObject testObject = new JSONObject(responseString);
-            if (testObject.has("Data")) {
-                // Result contains Data object (array).
-                result = GSON.fromJson(testObject.getString("Data"), clazz);
+            } else if (this.clazz == String.class) {
+                // If we want just a String, simply return the response.data casted as such.
+                result = (MojioResponse<T>) new MojioResponse<>(responseString);
             } else {
-                // Result does not contain the Data object - assumed to be a single result.
-                result = GSON.fromJson(responseString, clazz);
+                // this handles responses that wrap the data and have a Data element
+                // TODO constructing a JSONObject just to throw it away - is there a more efficient way?
+                JSONObject testObject = new JSONObject(responseString);
+                if (testObject.has("Data")) {
+                    // result contains Data object (array), parse as a MojioRequest directly
+                    Type typeToken = new TypeToken<MojioRequest<T>>() {}.getType();
+                    result = GSON.fromJson(responseString, typeToken);
+                } else {
+                    // result does not contain the Data object - assumed to be a single result.
+                    result = new MojioResponse<>(GSON.fromJson(responseString, clazz));
+                }
             }
 
+            result.setStatusCode(response.statusCode);
             return Response.success(result, HttpHeaderParser.parseCacheHeaders(response));
         } catch (Exception e) {
             Log.e(TAG, "Error parsing network response", e);

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioRequest.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioRequest.java
@@ -12,13 +12,11 @@ import com.android.volley.ParseError;
 import com.android.volley.Request;
 import com.android.volley.Response;
 import com.android.volley.toolbox.HttpHeaderParser;
-import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
 import org.json.JSONObject;
 
 import java.io.ByteArrayOutputStream;
-import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -196,14 +194,9 @@ public class MojioRequest<T> extends Request<MojioResponse<T>> {
                 result = (MojioResponse<T>) new MojioResponse<>(responseString);
             } else {
                 // this handles responses that wrap the data and have a Data element
-                // TODO constructing a JSONObject just to throw it away - is there a more efficient way?
                 JSONObject testObject = new JSONObject(responseString);
                 if (testObject.has(MojioResponse.ATTR_DATA)) {
-                    /* TODO this doesn't work for arrays - Gson force parses T (when an array) into an ArrayList for some reason
-                    // result contains Data object (array), parse as a MojioRequest directly
-                    Type type = new TypeToken<MojioResponse<T>>() {}.getType();
-                    result = MojioClient.getGson().fromJson(responseString, type);
-                    */
+                    // unfortunately using Gson to parse MojioResponse<T> directly with a TypeToken forces arrays to ArrayList when T is an array
                     T data = MojioClient.getGson().fromJson(testObject.getString(MojioResponse.ATTR_DATA), TypeToken.get(clazz).getType());
                     result = new MojioResponse<>(data);
                     result.setPageSize(testObject.getInt(MojioResponse.ATTR_PAGE_SIZE));

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioRequest.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioRequest.java
@@ -51,7 +51,6 @@ public class MojioRequest<T> extends Request<MojioResponse<T>> {
     private static final String TAG = MojioRequest.class.getSimpleName();
     private static final String PROTOCOL_CHARSET = "utf-8";
     private static final String PROTOCOL_CONTENT_TYPE = String.format("application/json; charset=%s", PROTOCOL_CHARSET);
-    private static final Gson GSON = new Gson();
 
     private Context mAppContext;
     private Class<T> clazz;
@@ -202,10 +201,10 @@ public class MojioRequest<T> extends Request<MojioResponse<T>> {
                 if (testObject.has("Data")) {
                     // result contains Data object (array), parse as a MojioRequest directly
                     Type typeToken = new TypeToken<MojioRequest<T>>() {}.getType();
-                    result = GSON.fromJson(responseString, typeToken);
+                    result = MojioClient.getGson().fromJson(responseString, typeToken);
                 } else {
                     // result does not contain the Data object - assumed to be a single result.
-                    result = new MojioResponse<>(GSON.fromJson(responseString, clazz));
+                    result = new MojioResponse<>(MojioClient.getGson().fromJson(responseString, clazz));
                 }
             }
 

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioResponse.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioResponse.java
@@ -1,0 +1,70 @@
+package io.moj.mobile.android.sdk.networking;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Model object for a Mojio API response.
+ * Created by skidson on 15-10-05.
+ */
+public class MojioResponse<T> {
+
+    @SerializedName("PageSize")
+    private int pageSize = 0;
+
+    @SerializedName("Offset")
+    private int offset = 0;
+
+    @SerializedName("TotalRows")
+    private int totalRows = 0;
+
+    @SerializedName("Data")
+    private T data;
+
+    private int statusCode;
+
+    public MojioResponse() {}
+
+    public MojioResponse(T data) {
+        this.data = data;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    public int getTotalRows() {
+        return totalRows;
+    }
+
+    public void setTotalRows(int totalRows) {
+        this.totalRows = totalRows;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+}

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioResponse.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioResponse.java
@@ -8,6 +8,8 @@ import com.google.gson.annotations.SerializedName;
  */
 public class MojioResponse<T> {
 
+    private int statusCode = 0;
+
     @SerializedName("PageSize")
     private int pageSize = 0;
 
@@ -19,8 +21,6 @@ public class MojioResponse<T> {
 
     @SerializedName("Data")
     private T data;
-
-    private int statusCode;
 
     public MojioResponse() {}
 

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioResponse.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioResponse.java
@@ -8,18 +8,21 @@ import com.google.gson.annotations.SerializedName;
  */
 public class MojioResponse<T> {
 
-    private int statusCode = 0;
+    public static final String ATTR_PAGE_SIZE = "PageSize";
+    public static final String ATTR_PAGE_OFFSET = "Offset";
+    public static final String ATTR_PAGE_TOTAL_ROWS = "TotalRows";
+    public static final String ATTR_DATA = "Data";
 
-    @SerializedName("PageSize")
+    @SerializedName(ATTR_PAGE_SIZE)
     private int pageSize = 0;
 
-    @SerializedName("Offset")
+    @SerializedName(ATTR_PAGE_OFFSET)
     private int offset = 0;
 
-    @SerializedName("TotalRows")
+    @SerializedName(ATTR_PAGE_TOTAL_ROWS)
     private int totalRows = 0;
 
-    @SerializedName("Data")
+    @SerializedName(ATTR_DATA)
     private T data;
 
     public MojioResponse() {}
@@ -60,11 +63,4 @@ public class MojioResponse<T> {
         this.totalRows = totalRows;
     }
 
-    public int getStatusCode() {
-        return statusCode;
-    }
-
-    public void setStatusCode(int statusCode) {
-        this.statusCode = statusCode;
-    }
 }

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioResponse.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/MojioResponse.java
@@ -63,4 +63,8 @@ public class MojioResponse<T> {
         this.totalRows = totalRows;
     }
 
+    public boolean hasMorePages() {
+        return pageSize + offset < totalRows;
+    }
+
 }


### PR DESCRIPTION
- This change now wraps all responses in a MojioResponse object that provides paging details to the client. Clients will be responsible for implementing paging as their app needs.
- Made MojioClient.ResponseListener implement both Volley's Response.Listener and Response.ErrorListener - this cuts out two object creations per every API call :)
