### PR TITLE
Detect endpoint changes off of cached endpoint

### DIFF
--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/DataStorageHelper.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/DataStorageHelper.java
@@ -29,20 +29,28 @@ public class DataStorageHelper {
         return getSharedPreferences().getString(PREF_ACCESS_TOKEN, null);
     }
 
+    /**
+     * Stores the access token.
+     * @param accessToken the access token
+     * @param expirationTime the expiration date of the access token
+     * @param endpoint the endpoint the access token was retrieved from
+     * @param isUserToken whether this access token is for an authenticated user
+     */
     @SuppressLint("CommitPrefEdits")
-    public void setAccessToken(String accessToken, String expirationTime, boolean isUserToken) {
+    public void setAccessToken(String accessToken, String expirationTime, String endpoint, boolean isUserToken) {
         long expirationTimestamp = TimeFormatHelpers.fromServerFormatted(expirationTime).getMillis();
 
         Editor sharedPreferences = mContext.getSharedPreferences(SHARED_PREF_ID, Context.MODE_PRIVATE).edit();
         sharedPreferences.putString(PREF_ACCESS_TOKEN, accessToken);
         sharedPreferences.putLong(PREF_ACCESS_TOKEN_EXPIRES, expirationTimestamp);
         sharedPreferences.putBoolean(PREF_ACCESS_TOKEN_IS_USER, isUserToken);
+        sharedPreferences.putString(PREF_APP_ENDPOINT, endpoint);
         sharedPreferences.commit();
     }
 
     @SuppressLint("CommitPrefEdits")
-    public void setAccessToken(String accessToken, String expirationTime) {
-        setAccessToken(accessToken, expirationTime, true);
+    public void setAccessToken(String accessToken, String expirationTime, String endpoint) {
+        setAccessToken(accessToken, expirationTime, endpoint, true);
     }
 
     public boolean shouldRefreshAccessToken() {
@@ -65,18 +73,6 @@ public class DataStorageHelper {
         return getSharedPreferences().getBoolean(PREF_ACCESS_TOKEN_IS_USER, false);
     }
 
-    /**
-     * Saves the end point with which the app token is valid.
-     *
-     * @param url The end point URL.
-     */
-    public void setEndpoint(String url) {
-        getSharedPreferences().edit().putString(PREF_APP_ENDPOINT, url).commit();
-    }
-
-    /**
-     * @return The end point with which the app token is valid.
-     */
     public String getEndpoint() {
         return getSharedPreferences().getString(PREF_APP_ENDPOINT, null);
     }
@@ -93,6 +89,7 @@ public class DataStorageHelper {
         getSharedPreferences().edit()
                 .remove(PREF_ACCESS_TOKEN)
                 .remove(PREF_ACCESS_TOKEN_EXPIRES)
+                .remove(PREF_APP_ENDPOINT)
                 .commit();
     }
 

--- a/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/OAuthLoginActivity.java
+++ b/MojioSDK/mojiosdksrc/src/main/java/io/moj/mobile/android/sdk/networking/OAuthLoginActivity.java
@@ -24,9 +24,9 @@ public class OAuthLoginActivity extends Activity {
         setContentView(R.layout.activity_oauth_login);
 
         Bundle extras = getIntent().getExtras();
-        _urlPath = extras.getString("URL_AUTH_PATH");
+        final String authUrl = extras.getString("URL_AUTH_PATH");
         _redirectUrl = extras.getString("REDIRECT_URL");
-        _urlPath += "&redirect_uri=" + _redirectUrl; // Add redirectUrl
+        _urlPath = authUrl + "&redirect_uri=" + _redirectUrl; // Add redirectUrl
         _oauthHelper = new DataStorageHelper(this);
 
         _loginWebView = (WebView) findViewById(R.id.loginwebview);
@@ -43,7 +43,7 @@ public class OAuthLoginActivity extends Activity {
                     String [] accessToken = parameters[0].split("=");
                     String [] expiresIn = parameters[2].split("=");
 
-                    _oauthHelper.setAccessToken(accessToken[1], expiresIn[1]);
+                    _oauthHelper.setAccessToken(accessToken[1], expiresIn[1], authUrl);
 
                     // Return in bundle, but also stored in shared prefs
                     Bundle bundle = new Bundle();


### PR DESCRIPTION
Endpoint changes are detected from the auth URL of the last access token rather than the in-memory state of MojioClient
