### PR TITLE
Observer construction tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![](static/banner_mojio.png)
 # Mojio Android SDK #
+![](http://ci.moj.io/app/rest/builds/buildType:(id:Mobile_MojioSDK_Android_Development)/statusIcon)
 
 Android SDK for integrating with the Mojio platform.
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ For more information please see the [developer website](http://developer.moj.io/
 
 ## Download ##
 ```gradle
-compile 'io.moj.mobile.android:mojio-sdk-auth:0.0.9'
-compile 'io.moj.mobile.android:mojio-sdk-common:0.0.9'
-compile 'io.moj.mobile.android:mojio-sdk-model:0.0.9'
-compile 'io.moj.mobile.android:mojio-sdk-push:0.0.9'
+compile 'io.moj.mobile.android:mojio-sdk-auth:0.0.10'
+compile 'io.moj.mobile.android:mojio-sdk-common:0.0.10'
+compile 'io.moj.mobile.android:mojio-sdk-model:0.0.10'
+compile 'io.moj.mobile.android:mojio-sdk-push:0.0.10'
 ```
 
 The Mojio Android SDK requires a minimum of Android 2.1 (API 7)

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     VERSION_CODE = 1
 
     PUBLISH_GROUP_ID = 'io.moj.mobile.android'
-    PUBLISH_VERSION = '0.0.9'
+    PUBLISH_VERSION = '0.0.10'
     GLOBAL_COVERAGE_EXCLUDES = [
             '**/R.class',
             '**/R$*.class',
@@ -34,7 +34,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta5'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
         classpath "org.jacoco:org.jacoco.core:0.7.2.201409121644"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/mojio-sdk-auth/README.md
+++ b/mojio-sdk-auth/README.md
@@ -11,7 +11,7 @@ web-based login flow.
 
 ## Download ##
 ```gradle
-compile 'io.moj.mobile.android:mojio-sdk-auth:0.0.9'
+compile 'io.moj.mobile.android:mojio-sdk-auth:0.0.10'
 ```
 
 ## Instructions ##

--- a/mojio-sdk-auth/build.gradle
+++ b/mojio-sdk-auth/build.gradle
@@ -36,7 +36,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.2.0'
-    compile 'io.moj.mobile.android:mojio-sdk-common:0.0.9'
+    compile 'io.moj.mobile.android:mojio-sdk-common:0.0.10'
 
     testCompile project(":mojio-sdk-test")
 

--- a/mojio-sdk-common/README.md
+++ b/mojio-sdk-common/README.md
@@ -11,7 +11,7 @@ configurable, logger.
 
 ## Download ##
 ```gradle
-compile 'io.moj.mobile.android:mojio-sdk-common:0.0.9'
+compile 'io.moj.mobile.android:mojio-sdk-common:0.0.10'
 ```
 
 ## Instructions ##

--- a/mojio-sdk-model/README.md
+++ b/mojio-sdk-model/README.md
@@ -11,7 +11,7 @@ GSON.
 
 ## Download ##
 ```gradle
-compile 'io.moj.mobile.android:mojio-sdk-model:0.0.9'
+compile 'io.moj.mobile.android:mojio-sdk-model:0.0.10'
 ```
 
 ## Instructions ##

--- a/mojio-sdk-push/README.md
+++ b/mojio-sdk-push/README.md
@@ -11,7 +11,7 @@ GSON.
 
 ## Download ##
 ```gradle
-compile 'io.moj.mobile.android:mojio-sdk-push:0.0.9'
+compile 'io.moj.mobile.android:mojio-sdk-push:0.0.10'
 ```
 
 ## Instructions ##

--- a/mojio-sdk-push/src/main/java/io/moj/mobile/android/sdk/push/Condition.java
+++ b/mojio-sdk-push/src/main/java/io/moj/mobile/android/sdk/push/Condition.java
@@ -47,6 +47,18 @@ public class Condition {
         this.type = type;
     }
 
+    public Condition(Condition other) {
+        this.type = other.type;
+        this.Property = other.Property;
+        this.Position = other.Position;
+        this.Max = other.Max;
+        this.Min = other.Min;
+        this.TimeProperty = other.TimeProperty;
+        this.Delay = other.Delay;
+        this.MinDataPoints = other.MinDataPoints;
+        this.Window = other.Window;
+    }
+
     public String getDelay() {
         return Delay;
     }

--- a/mojio-sdk-push/src/main/java/io/moj/mobile/android/sdk/push/Condition.java
+++ b/mojio-sdk-push/src/main/java/io/moj/mobile/android/sdk/push/Condition.java
@@ -47,18 +47,6 @@ public class Condition {
         this.type = type;
     }
 
-    public Condition(Condition other) {
-        this.type = other.type;
-        this.Property = other.Property;
-        this.Position = other.Position;
-        this.Max = other.Max;
-        this.Min = other.Min;
-        this.TimeProperty = other.TimeProperty;
-        this.Delay = other.Delay;
-        this.MinDataPoints = other.MinDataPoints;
-        this.Window = other.Window;
-    }
-
     public String getDelay() {
         return Delay;
     }

--- a/mojio-sdk-push/src/main/java/io/moj/mobile/android/sdk/push/ObserverCreationRequest.java
+++ b/mojio-sdk-push/src/main/java/io/moj/mobile/android/sdk/push/ObserverCreationRequest.java
@@ -142,7 +142,7 @@ public class ObserverCreationRequest {
          */
         public ObserverCreationRequest build() {
             return new ObserverCreationRequest(key, subject, type, transport, propertyChanged,
-                    threshold, debounce, throttle, fields);
+                    threshold, debounce, throttle, new ArrayList<>(fields));
         }
     }
 

--- a/mojio-sdk-push/src/main/java/io/moj/mobile/android/sdk/push/ObserverCreationRequest.java
+++ b/mojio-sdk-push/src/main/java/io/moj/mobile/android/sdk/push/ObserverCreationRequest.java
@@ -25,24 +25,31 @@ public class ObserverCreationRequest {
 
     public ObserverCreationRequest() {}
 
-    public ObserverCreationRequest(ObserverCreationRequest other) {
-        this.Key = other.Key;
-        this.CreatedOn = other.CreatedOn;
-        this.LastModified = other.LastModified;
-        this.ExpiryDate = other.ExpiryDate;
-        this.Name = other.Name;
-        this.Subject = other.Subject;
-        this.Fields = other.Fields;
-        this.PropertyChanged = other.PropertyChanged;
-        this.Threshold = other.Threshold;
-        this.Debounce = other.Debounce;
-        this.Throttle = other.Throttle;
-        this.Transport = other.Transport;
-        this.Type = other.Type;
+    private ObserverCreationRequest(String key, String subject, Observer.Type type,
+                                    Transport transport, String propertyChanged,
+                                    Condition threshold, Condition debounce, Condition throttle,
+                                    List<String> fields) {
+        this.Key = key;
+        this.Subject = subject;
+        this.Type = type;
+        this.Transport = transport;
+        this.PropertyChanged = propertyChanged;
+        this.Threshold = threshold;
+        this.Debounce = debounce;
+        this.Throttle = throttle;
+        this.Fields = fields;
     }
 
     public static class Builder {
-        private ObserverCreationRequest request;
+        private String key;
+        private String subject;
+        private Observer.Type type;
+        private Transport transport;
+        private String propertyChanged;
+        private Condition threshold;
+        private Condition debounce;
+        private Condition throttle;
+        private List<String> fields;
 
         /**
          * Constructs an Observer builder.
@@ -50,8 +57,7 @@ public class ObserverCreationRequest {
          *            application and entity. It cannot be edited.
          */
         public Builder(String key) {
-            request = new ObserverCreationRequest();
-            request.Key = key;
+            this.key = key;
         }
 
         /**
@@ -63,7 +69,7 @@ public class ObserverCreationRequest {
          * @return
          */
         public Builder subject(String subject) {
-            request.Subject = subject;
+            this.subject = subject;
             return this;
         }
 
@@ -75,7 +81,7 @@ public class ObserverCreationRequest {
          * @return
          */
         public Builder type(Observer.Type type) {
-            request.Type = type;
+            this.type = type;
             return this;
         }
 
@@ -87,7 +93,7 @@ public class ObserverCreationRequest {
          * @return
          */
         public Builder transport(Transport transport) {
-            request.Transport = transport;
+            this.transport = transport;
             return this;
         }
 
@@ -101,16 +107,16 @@ public class ObserverCreationRequest {
         public Builder condition(Condition condition) {
             switch (condition.getType()) {
                 case PROPERTY_CHANGED:
-                    request.PropertyChanged = condition.getProperty();
+                    this.propertyChanged = condition.getProperty();
                     break;
                 case THRESHOLD:
-                    request.Threshold = condition;
+                    this.threshold = condition;
                     break;
                 case DEBOUNCE:
-                    request.Debounce = condition;
+                    this.debounce = condition;
                     break;
                 case THROTTLE:
-                    request.Throttle = condition;
+                    this.throttle = condition;
                     break;
             }
             return this;
@@ -124,9 +130,9 @@ public class ObserverCreationRequest {
          * @return
          */
         public Builder field(String field) {
-            if (request.Fields == null)
-                request.Fields = new ArrayList<>();
-            request.Fields.add(field);
+            if (fields == null)
+                fields = new ArrayList<>();
+            fields.add(field);
             return this;
         }
 
@@ -135,7 +141,8 @@ public class ObserverCreationRequest {
          * @return
          */
         public ObserverCreationRequest build() {
-            return new ObserverCreationRequest(request);
+            return new ObserverCreationRequest(key, subject, type, transport, propertyChanged,
+                    threshold, debounce, throttle, fields);
         }
     }
 

--- a/mojio-sdk-push/src/main/java/io/moj/mobile/android/sdk/push/ObserverCreationRequest.java
+++ b/mojio-sdk-push/src/main/java/io/moj/mobile/android/sdk/push/ObserverCreationRequest.java
@@ -23,6 +23,24 @@ public class ObserverCreationRequest {
     private Transport Transport;
     private Observer.Type Type;
 
+    public ObserverCreationRequest() {}
+
+    public ObserverCreationRequest(ObserverCreationRequest other) {
+        this.Key = other.Key;
+        this.CreatedOn = other.CreatedOn;
+        this.LastModified = other.LastModified;
+        this.ExpiryDate = other.ExpiryDate;
+        this.Name = other.Name;
+        this.Subject = other.Subject;
+        this.Fields = other.Fields;
+        this.PropertyChanged = other.PropertyChanged;
+        this.Threshold = other.Threshold;
+        this.Debounce = other.Debounce;
+        this.Throttle = other.Throttle;
+        this.Transport = other.Transport;
+        this.Type = other.Type;
+    }
+
     public static class Builder {
         private ObserverCreationRequest request;
 
@@ -117,7 +135,7 @@ public class ObserverCreationRequest {
          * @return
          */
         public ObserverCreationRequest build() {
-            return request;
+            return new ObserverCreationRequest(request);
         }
     }
 

--- a/mojio-sdk-push/src/test/java/io/moj/mobile/android/sdk/push/ObserverCreationRequestTest.java
+++ b/mojio-sdk-push/src/test/java/io/moj/mobile/android/sdk/push/ObserverCreationRequestTest.java
@@ -6,7 +6,9 @@ import org.junit.Test;
 
 import io.moj.mobile.android.sdk.TestJson;
 
+import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 
 /**
  * Created by skidson on 16-02-18.
@@ -35,6 +37,30 @@ public class ObserverCreationRequestTest {
 
         String json = new Gson().toJson(o, ObserverCreationRequest.class);
         assertEquals(TestJson.OBSERVER_REQUEST, json);
+    }
+
+    @Test
+    public void testBuild_unique() {
+        String key = "key";
+        String subject = "subject";
+        Observer.Type type = Observer.Type.MOJIO;
+        Transport transport = Transport.forAndroid("gcmRegId");
+        String[] fields = new String[] { "LastContactTime", "LastContactTime" };
+
+        ObserverCreationRequest.Builder builder = new ObserverCreationRequest.Builder(key)
+                .subject(subject)
+                .type(type)
+                .transport(transport)
+                .condition(Condition.onPropertyChanged("Property"))
+                .condition(Condition.onThreshold("Property", Condition.Position.ABOVE, 1d, 2d))
+                .condition(Condition.throttle("Speed.Value", "0.00:01:00.0000"))
+                .condition(Condition.debounce(1, 2, 3, 4, 5))
+                .field(fields[0])
+                .field(fields[1]);
+
+        ObserverCreationRequest requestA = builder.build();
+        ObserverCreationRequest requestB = builder.build();
+        assertFalse(requestA == requestB);
     }
 
 }

--- a/mojio-sdk-push/src/test/java/io/moj/mobile/android/sdk/push/ObserverCreationRequestTest.java
+++ b/mojio-sdk-push/src/test/java/io/moj/mobile/android/sdk/push/ObserverCreationRequestTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 
 import io.moj.mobile.android.sdk.TestJson;
 
-import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 


### PR DESCRIPTION
- Changed ObserverCreationRequest.Builder to only create the ObserverCreationRequest at the time build() is called. This prevents unexpected modifications to previously created requests when using the same builder. For example:

```
ObserverCreationRequest.Builder builder = new ObserverCreationRequest.Builder(key)
                    .type(Observer.Type.VEHICLE)
                    .transport(transport)
                    .condition(condition);
for (Vehicle vehicle : vehicles) {
    builder.subject(vehicle.getId());
    ObserverCreationRequest request = builder.build();
    App.getMojioPushApi().observeVehicle(vehicle.getId(), request)
            .enqueue(new CreateObserverCallback(this));
}
```

... with the old code, the request objects in each previous iteration would have their subject modified, which could result in all the observers being created for the same vehicle instead of one for each.
- Wrote a unit test to ensure subsequent objects created from ObserverCreationRequest.Builder.build() do not refer to the same object.
- Added a TeamCity build status badge _(TODO make this a standard icon using shields.io after we upgrade past TC 9.1.2)_
- Upgraded Android Gradle plugin to 2.0.0-beta6
- Tagged as build 0.0.10
