### PR TITLE
Fixed crash when creating an observer with no fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     VERSION_CODE = 1
 
     PUBLISH_GROUP_ID = 'io.moj.mobile.android'
-    PUBLISH_VERSION = '0.0.10'
+    PUBLISH_VERSION = '0.0.11'
     GLOBAL_COVERAGE_EXCLUDES = [
             '**/R.class',
             '**/R$*.class',

--- a/mojio-sdk-auth/build.gradle
+++ b/mojio-sdk-auth/build.gradle
@@ -36,7 +36,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.2.0'
-    compile 'io.moj.mobile.android:mojio-sdk-common:0.0.10'
+    compile 'io.moj.mobile.android:mojio-sdk-common:0.0.11'
 
     testCompile project(":mojio-sdk-test")
 

--- a/mojio-sdk-push/src/main/java/io/moj/mobile/android/sdk/push/ObserverCreationRequest.java
+++ b/mojio-sdk-push/src/main/java/io/moj/mobile/android/sdk/push/ObserverCreationRequest.java
@@ -1,5 +1,7 @@
 package io.moj.mobile.android.sdk.push;
 
+import android.text.TextUtils;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,7 +27,7 @@ public class ObserverCreationRequest {
 
     public ObserverCreationRequest() {}
 
-    private ObserverCreationRequest(String key, String subject, Observer.Type type,
+    private ObserverCreationRequest(String key, Observer.Type type, String subject,
                                     Transport transport, String propertyChanged,
                                     Condition threshold, Condition debounce, Condition throttle,
                                     List<String> fields) {
@@ -141,8 +143,10 @@ public class ObserverCreationRequest {
          * @return
          */
         public ObserverCreationRequest build() {
-            return new ObserverCreationRequest(key, subject, type, transport, propertyChanged,
-                    threshold, debounce, throttle, new ArrayList<>(fields));
+            if (type == null)
+                throw new IllegalStateException("Type must not be null");
+            return new ObserverCreationRequest(key, type, subject, transport, propertyChanged,
+                    threshold, debounce, throttle, fields == null ? null : new ArrayList<>(fields));
         }
     }
 

--- a/mojio-sdk-push/src/test/java/io/moj/mobile/android/sdk/push/ObserverCreationRequestTest.java
+++ b/mojio-sdk-push/src/test/java/io/moj/mobile/android/sdk/push/ObserverCreationRequestTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import io.moj.mobile.android.sdk.TestJson;
 
+import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 
@@ -60,6 +61,25 @@ public class ObserverCreationRequestTest {
         ObserverCreationRequest requestA = builder.build();
         ObserverCreationRequest requestB = builder.build();
         assertFalse(requestA == requestB);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testBuild_empty() {
+        String key = "key";
+        new ObserverCreationRequest.Builder(key).build();
+    }
+
+    @Test
+    public void testSerialization_minimal() {
+        String key = "key";
+        Observer.Type type = Observer.Type.MOJIO;
+
+        ObserverCreationRequest request = new ObserverCreationRequest.Builder(key)
+                .type(type).build();
+        assertThat(request).isNotNull();
+
+        String json = new Gson().toJson(request, ObserverCreationRequest.class);
+        assertThat(json).isEqualTo("{\"Key\":\"key\",\"Type\":\"mojio\"}");
     }
 
 }


### PR DESCRIPTION
- Fixed a NullPointerException when calling build with no fields set (tried copying a null ArrayList). Added test to ensure this code path is tested going forward.
- Ensured an observer has at least a key and type set when trying to build
- Tagged as release 0.0.11
