### PR TITLE
Separate VinDetails and "VehicleDetails"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ For more information please see the [developer website](http://developer.moj.io/
 
 ## Download ##
 ```gradle
-compile 'io.moj.mobile.android:mojio-sdk-auth:0.0.14'
-compile 'io.moj.mobile.android:mojio-sdk-common:0.0.14'
-compile 'io.moj.mobile.android:mojio-sdk-model:0.0.14'
-compile 'io.moj.mobile.android:mojio-sdk-push:0.0.14'
+compile 'io.moj.mobile.android:mojio-sdk-auth:0.0.15'
+compile 'io.moj.mobile.android:mojio-sdk-common:0.0.15'
+compile 'io.moj.mobile.android:mojio-sdk-model:0.0.15'
+compile 'io.moj.mobile.android:mojio-sdk-push:0.0.15'
 ```
 
 The Mojio Android SDK requires a minimum of Android 2.1 (API 7)

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     VERSION_CODE = 1
 
     PUBLISH_GROUP_ID = 'io.moj.mobile.android'
-    PUBLISH_VERSION = '0.0.14'
+    PUBLISH_VERSION = '0.0.15'
     GLOBAL_COVERAGE_EXCLUDES = [
             '**/R.class',
             '**/R$*.class',

--- a/mojio-sdk-auth/README.md
+++ b/mojio-sdk-auth/README.md
@@ -11,7 +11,7 @@ web-based login flow.
 
 ## Download ##
 ```gradle
-compile 'io.moj.mobile.android:mojio-sdk-auth:0.0.14'
+compile 'io.moj.mobile.android:mojio-sdk-auth:0.0.15'
 ```
 
 ## Instructions ##

--- a/mojio-sdk-auth/build.gradle
+++ b/mojio-sdk-auth/build.gradle
@@ -36,7 +36,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.2.0'
-    compile 'io.moj.mobile.android:mojio-sdk-common:0.0.14'
+    compile 'io.moj.mobile.android:mojio-sdk-common:0.0.15'
 
     testCompile project(":mojio-sdk-test")
 

--- a/mojio-sdk-common/README.md
+++ b/mojio-sdk-common/README.md
@@ -11,7 +11,7 @@ configurable, logger.
 
 ## Download ##
 ```gradle
-compile 'io.moj.mobile.android:mojio-sdk-common:0.0.14'
+compile 'io.moj.mobile.android:mojio-sdk-common:0.0.15'
 ```
 
 ## Instructions ##

--- a/mojio-sdk-model/README.md
+++ b/mojio-sdk-model/README.md
@@ -11,7 +11,7 @@ GSON.
 
 ## Download ##
 ```gradle
-compile 'io.moj.mobile.android:mojio-sdk-model:0.0.14'
+compile 'io.moj.mobile.android:mojio-sdk-model:0.0.15'
 ```
 
 ## Instructions ##

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/AbstractMojioObject.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/AbstractMojioObject.java
@@ -1,0 +1,75 @@
+package io.moj.mobile.android.sdk.model;
+
+import io.moj.mobile.android.sdk.model.values.LinkInfo;
+
+/**
+ * Base model for objects returned by the server.
+ * Note: field names are the same as used by the backend so that if reflection is used for
+ * serialization or persistence to database, then the column name will be the same.
+ * Created by mhorie on 2016-01-13.
+ */
+public abstract class AbstractMojioObject implements MojioObject {
+
+    public static final String LOCAL_ID = "_id";
+    public static final String CREATED_ON = "CreatedOn";
+    public static final String LAST_MODIFIED = "LastModified";
+    public static final String LINKS = "Links";
+
+    private String Id;
+    private Long _id;
+    private String CreatedOn;
+    private String LastModified;
+    private LinkInfo Links;
+
+    public String getCreatedOn() {
+        return CreatedOn;
+    }
+
+    public void setCreatedOn(String createdOn) {
+        CreatedOn = createdOn;
+    }
+
+    @Override
+    public String getId() {
+        return Id;
+    }
+
+    public void setId(String id) {
+        Id = id;
+    }
+
+    public String getLastModified() {
+        return LastModified;
+    }
+
+    public void setLastModified(String lastModified) {
+        LastModified = lastModified;
+    }
+
+    public Long getLocalId() {
+        return _id;
+    }
+
+    public void setLocalId(Long id) {
+        this._id = id;
+    }
+
+    public LinkInfo getLinks() {
+        return Links;
+    }
+
+    public void setLinks(LinkInfo links) {
+        Links = links;
+    }
+
+    @Override
+    public String toString() {
+        return "AbstractMojioObject{" +
+                "_id=" + _id +
+                ", Id='" + Id + '\'' +
+                ", CreatedOn='" + CreatedOn + '\'' +
+                ", LastModified='" + LastModified + '\'' +
+                ", Links=" + Links +
+                '}';
+    }
+}

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/App.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/App.java
@@ -8,7 +8,7 @@ import io.moj.mobile.android.sdk.model.values.Image;
  * Model object for an App.
  * Created by mhorie on 2016-01-12.
  */
-public class App extends MojioObject {
+public class App extends AbstractMojioObject {
 
     public static final String NAME = "Name";
     public static final String DESCRIPTION = "Description";

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/Group.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/Group.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
  * Model object for a Group.
  * Created by mhorie on 2016-01-12.
  */
-public class Group extends MojioObject {
+public class Group extends AbstractMojioObject {
 
     public static final String NAME = "Name";
     public static final String DESCRIPTION = "Description";

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/Mojio.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/Mojio.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
  * Model object for an Mojio.
  * Created by mhorie on 2016-01-13.
  */
-public class Mojio extends MojioObject {
+public class Mojio extends AbstractMojioObject {
 
     public static final String NAME = "Name";
     public static final String DEVICE_IMEI = "IMEI";

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/MojioObject.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/MojioObject.java
@@ -1,75 +1,12 @@
 package io.moj.mobile.android.sdk.model;
 
-import io.moj.mobile.android.sdk.model.values.LinkInfo;
-
 /**
- * Base model for objects returned by the server.
- * Note: field names are the same as used by the backend so that if reflection is used for
- * serialization or persistence to database, then the column name will be the same.
- * Created by mhorie on 2016-01-13.
+ * Created by skidson on 16-03-30.
  */
-public abstract class MojioObject {
+public interface MojioObject {
 
     public static final String ID = "Id";
-    public static final String LOCAL_ID = "_id";
-    public static final String CREATED_ON = "CreatedOn";
-    public static final String LAST_MODIFIED = "LastModified";
-    public static final String LINKS = "Links";
 
-    private String Id;
-    private Long _id;
-    private String CreatedOn;
-    private String LastModified;
-    private LinkInfo Links;
+    String getId();
 
-    public String getCreatedOn() {
-        return CreatedOn;
-    }
-
-    public void setCreatedOn(String createdOn) {
-        CreatedOn = createdOn;
-    }
-
-    public String getId() {
-        return Id;
-    }
-
-    public void setId(String id) {
-        Id = id;
-    }
-
-    public String getLastModified() {
-        return LastModified;
-    }
-
-    public void setLastModified(String lastModified) {
-        LastModified = lastModified;
-    }
-
-    public Long getLocalId() {
-        return _id;
-    }
-
-    public void setLocalId(Long id) {
-        this._id = id;
-    }
-
-    public LinkInfo getLinks() {
-        return Links;
-    }
-
-    public void setLinks(LinkInfo links) {
-        Links = links;
-    }
-
-    @Override
-    public String toString() {
-        return "MojioObject{" +
-                "_id=" + _id +
-                ", Id='" + Id + '\'' +
-                ", CreatedOn='" + CreatedOn + '\'' +
-                ", LastModified='" + LastModified + '\'' +
-                ", Links=" + Links +
-                '}';
-    }
 }

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/Trip.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/Trip.java
@@ -14,7 +14,7 @@ import io.moj.mobile.android.sdk.model.values.Speed;
  * Model object for a Trip.
  * Created by mhorie on 2016-01-13.
  */
-public class Trip extends MojioObject {
+public class Trip extends AbstractMojioObject {
 
     public static final String VEHICLE_ID = "VehicleId";
     public static final String NAME = "Name";

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/User.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/User.java
@@ -10,7 +10,7 @@ import io.moj.mobile.android.sdk.model.values.PhoneNumber;
  * Model object for an User.
  * Created by mojio on 2016-01-13.
  */
-public class User extends MojioObject {
+public class User extends AbstractMojioObject {
 
     public static final String FIRST_NAME = "FirstName";
     public static final String LAST_NAME = "LastName";

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/Vehicle.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/Vehicle.java
@@ -17,13 +17,13 @@ import io.moj.mobile.android.sdk.model.values.Location;
 import io.moj.mobile.android.sdk.model.values.Odometer;
 import io.moj.mobile.android.sdk.model.values.Rpm;
 import io.moj.mobile.android.sdk.model.values.Speed;
-import io.moj.mobile.android.sdk.model.values.VinDetails;
+import io.moj.mobile.android.sdk.model.values.VehicleDetails;
 
 /**
  * Model object for an Vehicle.
  * Created by mhorie on 2016-01-13.
  */
-public class Vehicle extends MojioObject {
+public class Vehicle extends AbstractMojioObject {
 
     public static final String NAME = "Name";
     public static final String LICENSE_PLATE = "LicensePlate";
@@ -84,7 +84,7 @@ public class Vehicle extends MojioObject {
     private Heading Heading;
     private Location Location;
     private BooleanState AccidentState;
-    private VinDetails VinDetails;
+    private VehicleDetails VinDetails;
     private BooleanState TowState;
     private BooleanState ParkedState;
     private String[] Tags;
@@ -332,11 +332,11 @@ public class Vehicle extends MojioObject {
         this.VIN = VIN;
     }
 
-    public VinDetails getVinDetails() {
+    public VehicleDetails getVinDetails() {
         return VinDetails;
     }
 
-    public void setVinDetails(VinDetails vinDetails) {
+    public void setVinDetails(VehicleDetails vinDetails) {
         VinDetails = vinDetails;
     }
 

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/VehicleMeasure.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/VehicleMeasure.java
@@ -17,13 +17,10 @@ import io.moj.mobile.android.sdk.model.values.Speed;
 import io.moj.mobile.android.sdk.model.values.VinDetails;
 
 /**
- * Model object for an VehicleMeasure. A VehicleMeasure is what is returned by calls to v2/.../history/states.
- * It is not an entity per se as it neither has an ID nor a reference to its parent object when returned
- * by the server, but it is being subclassed from MojioObject here because it is worth caching or
- * persisting at the application layer due to its size.
+ * Model object for an vehicle measurement at a given point in time.
  * Created by mhorie on 2016-01-13.
  */
-public class VehicleMeasure extends MojioObject {
+public class VehicleMeasure {
 
     public static final String ACCELERATION = "Acceleration";
     public static final String ACCELEROMETER = "Accelerometer";
@@ -341,6 +338,6 @@ public class VehicleMeasure extends MojioObject {
                 ", VirtualOdometer=" + VirtualOdometer +
                 ", Odometer=" + Odometer +
                 ", Time='" + Time + '\'' +
-                "} " + super.toString();
+                '}';
     }
 }

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/enums/RiskSeverity.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/enums/RiskSeverity.java
@@ -3,10 +3,13 @@ package io.moj.mobile.android.sdk.model.enums;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * Enum for RiskSeverity types.
+ * Enum for RiskSeverity types. Ordinality can be inferred as increasing severity.
  * Created by mhorie on 2016-01-14.
  */
 public enum RiskSeverity {
+
+    @SerializedName("None")
+    NONE("None"),
 
     @SerializedName("Unknown")
     UNKNOWN("Unknown"),
@@ -18,10 +21,7 @@ public enum RiskSeverity {
     MEDIUM("Medium"),
 
     @SerializedName("High")
-    HIGH("High"),
-
-    @SerializedName("None")
-    NONE("None");
+    HIGH("High");
 
     private String key;
 

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/values/DiagnosticCode.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/values/DiagnosticCode.java
@@ -8,11 +8,11 @@ import io.moj.mobile.android.sdk.model.enums.RiskSeverity;
  */
 public class DiagnosticCode {
 
-    public String Code;
-    public String Description ;
-    public String Timestamp;
-    public RiskSeverity Severity;
-    public String Instructions;
+    private String Code;
+    private String Description ;
+    private String Timestamp;
+    private RiskSeverity Severity;
+    private String Instructions;
 
     public String getCode() {
         return Code;

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/values/FuelLevel.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/values/FuelLevel.java
@@ -1,12 +1,15 @@
 package io.moj.mobile.android.sdk.model.values;
 
 import io.moj.mobile.android.sdk.model.enums.FuelLevelUnit;
+import io.moj.mobile.android.sdk.model.enums.RiskSeverity;
 
 /**
  * Model object for a FuelLevel value.
  * Created by mhorie on 2016-01-14.
  */
 public class FuelLevel extends DeviceMeasurement {
+
+    private RiskSeverity RiskSeverity;
 
     public FuelLevelUnit getBaseFuelLevelUnit() {
         return FuelLevelUnit.fromKey(getBaseUnit());
@@ -24,8 +27,18 @@ public class FuelLevel extends DeviceMeasurement {
         setUnit(unit.getKey());
     }
 
+    public RiskSeverity getRiskSeverity() {
+        return RiskSeverity;
+    }
+
+    public void setRiskSeverity(RiskSeverity riskSeverity) {
+        RiskSeverity = riskSeverity;
+    }
+
     @Override
     public String toString() {
-        return "FuelLevel{} " + super.toString();
+        return "FuelLevel{" +
+                "RiskSeverity=" + RiskSeverity +
+                "} " + super.toString();
     }
 }

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/values/VehicleDetails.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/values/VehicleDetails.java
@@ -54,11 +54,11 @@ public class VehicleDetails {
         Engine = engine;
     }
 
-    public io.moj.mobile.android.sdk.model.enums.FuelType getFuelType() {
+    public FuelType getFuelType() {
         return FuelType;
     }
 
-    public void setFuelType(io.moj.mobile.android.sdk.model.enums.FuelType fuelType) {
+    public void setFuelType(FuelType fuelType) {
         FuelType = fuelType;
     }
 

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/values/VehicleDetails.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/values/VehicleDetails.java
@@ -1,0 +1,147 @@
+package io.moj.mobile.android.sdk.model.values;
+
+import io.moj.mobile.android.sdk.model.enums.FuelType;
+
+/**
+ * Model object for vehicle details based on VIN.
+ * Created by mhorie on 2016-01-14.
+ */
+public class VehicleDetails {
+
+    private String Vin;
+    private String Timestamp;
+    private Integer Year;
+    private String Make;
+    private String Model;
+    private String Engine;
+    private Integer Cyclinders;
+    private FuelCapacity TotalFuelCapacity;
+    private FuelType FuelType;
+    private Double CityFuelEfficiency;
+    private Double HighwayFuelEfficiency;
+    private Double CombinedFuelEfficiency;
+    private String Transmission;
+
+    public Double getCityFuelEfficiency() {
+        return CityFuelEfficiency;
+    }
+
+    public void setCityFuelEfficiency(Double cityFuelEfficiency) {
+        CityFuelEfficiency = cityFuelEfficiency;
+    }
+
+    public Double getCombinedFuelEfficiency() {
+        return CombinedFuelEfficiency;
+    }
+
+    public void setCombinedFuelEfficiency(Double combinedFuelEfficiency) {
+        CombinedFuelEfficiency = combinedFuelEfficiency;
+    }
+
+    public Integer getCyclinders() {
+        return Cyclinders;
+    }
+
+    public void setCyclinders(Integer cyclinders) {
+        Cyclinders = cyclinders;
+    }
+
+    public String getEngine() {
+        return Engine;
+    }
+
+    public void setEngine(String engine) {
+        Engine = engine;
+    }
+
+    public io.moj.mobile.android.sdk.model.enums.FuelType getFuelType() {
+        return FuelType;
+    }
+
+    public void setFuelType(io.moj.mobile.android.sdk.model.enums.FuelType fuelType) {
+        FuelType = fuelType;
+    }
+
+    public Double getHighwayFuelEfficiency() {
+        return HighwayFuelEfficiency;
+    }
+
+    public void setHighwayFuelEfficiency(Double highwayFuelEfficiency) {
+        HighwayFuelEfficiency = highwayFuelEfficiency;
+    }
+
+    public String getMake() {
+        return Make;
+    }
+
+    public void setMake(String make) {
+        Make = make;
+    }
+
+    public String getModel() {
+        return Model;
+    }
+
+    public void setModel(String model) {
+        Model = model;
+    }
+
+    public String getTimestamp() {
+        return Timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        Timestamp = timestamp;
+    }
+
+    public FuelCapacity getTotalFuelCapacity() {
+        return TotalFuelCapacity;
+    }
+
+    public void setTotalFuelCapacity(FuelCapacity totalFuelCapacity) {
+        TotalFuelCapacity = totalFuelCapacity;
+    }
+
+    public String getTransmission() {
+        return Transmission;
+    }
+
+    public void setTransmission(String transmission) {
+        Transmission = transmission;
+    }
+
+    public String getVin() {
+        return Vin;
+    }
+
+    public void setVin(String vin) {
+        Vin = vin;
+    }
+
+    public Integer getYear() {
+        return Year;
+    }
+
+    public void setYear(Integer year) {
+        Year = year;
+    }
+
+    @Override
+    public String toString() {
+        return "VehicleDetails{" +
+                "CityFuelEfficiency=" + CityFuelEfficiency +
+                ", Vin='" + Vin + '\'' +
+                ", Timestamp='" + Timestamp + '\'' +
+                ", Year=" + Year +
+                ", Make='" + Make + '\'' +
+                ", Model='" + Model + '\'' +
+                ", Engine='" + Engine + '\'' +
+                ", Cyclinders=" + Cyclinders +
+                ", TotalFuelCapacity=" + TotalFuelCapacity +
+                ", FuelType=" + FuelType +
+                ", HighwayFuelEfficiency=" + HighwayFuelEfficiency +
+                ", CombinedFuelEfficiency=" + CombinedFuelEfficiency +
+                ", Transmission='" + Transmission + '\'' +
+                '}';
+    }
+}

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/values/VinDetails.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/values/VinDetails.java
@@ -41,11 +41,11 @@ public class VinDetails {
         DriveType = driveType;
     }
 
-    public io.moj.mobile.android.sdk.model.values.Engine getEngine() {
+    public Engine getEngine() {
         return Engine;
     }
 
-    public void setEngine(io.moj.mobile.android.sdk.model.values.Engine engine) {
+    public void setEngine(Engine engine) {
         Engine = engine;
     }
 
@@ -113,11 +113,11 @@ public class VinDetails {
         Timestamp = timestamp;
     }
 
-    public io.moj.mobile.android.sdk.model.values.Transmission getTransmission() {
+    public Transmission getTransmission() {
         return Transmission;
     }
 
-    public void setTransmission(io.moj.mobile.android.sdk.model.values.Transmission transmission) {
+    public void setTransmission(Transmission transmission) {
         Transmission = transmission;
     }
 

--- a/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/values/VinDetails.java
+++ b/mojio-sdk-model/src/main/java/io/moj/mobile/android/sdk/model/values/VinDetails.java
@@ -3,12 +3,12 @@ package io.moj.mobile.android.sdk.model.values;
 import java.util.List;
 
 /**
- * Model object for vehicle details based on VIN.
+ * Model object for a vehicle's VIN record.
  * Created by mhorie on 2016-01-14.
  */
 public class VinDetails {
 
-    private String Vin;
+    private String VIN;
     private String Timestamp;
     private String Market;
     private Integer Year;
@@ -19,8 +19,8 @@ public class VinDetails {
     private String DriveType;
     private Double FuelTankSize;
     private Double EPAFuelEfficiency;
-    private String Engine;
-    private String Transmission;
+    private Engine Engine;
+    private Transmission Transmission;
     private List<Warranty> Warranties;
     private List<Recall> Recalls;
     private List<ServiceBulletin> ServiceBulletins;
@@ -39,6 +39,14 @@ public class VinDetails {
 
     public void setDriveType(String driveType) {
         DriveType = driveType;
+    }
+
+    public io.moj.mobile.android.sdk.model.values.Engine getEngine() {
+        return Engine;
+    }
+
+    public void setEngine(io.moj.mobile.android.sdk.model.values.Engine engine) {
+        Engine = engine;
     }
 
     public Double getEPAFuelEfficiency() {
@@ -105,6 +113,14 @@ public class VinDetails {
         Timestamp = timestamp;
     }
 
+    public io.moj.mobile.android.sdk.model.values.Transmission getTransmission() {
+        return Transmission;
+    }
+
+    public void setTransmission(io.moj.mobile.android.sdk.model.values.Transmission transmission) {
+        Transmission = transmission;
+    }
+
     public String getVehicleType() {
         return VehicleType;
     }
@@ -113,12 +129,12 @@ public class VinDetails {
         VehicleType = vehicleType;
     }
 
-    public String getVin() {
-        return Vin;
+    public String getVIN() {
+        return VIN;
     }
 
-    public void setVin(String vin) {
-        Vin = vin;
+    public void setVIN(String VIN) {
+        this.VIN = VIN;
     }
 
     public List<Warranty> getWarranties() {
@@ -137,27 +153,11 @@ public class VinDetails {
         Year = year;
     }
 
-    public String getEngine() {
-        return Engine;
-    }
-
-    public void setEngine(String engine) {
-        Engine = engine;
-    }
-
-    public String getTransmission() {
-        return Transmission;
-    }
-
-    public void setTransmission(String transmission) {
-        Transmission = transmission;
-    }
-
     @Override
     public String toString() {
         return "VinDetails{" +
                 "BodyType='" + BodyType + '\'' +
-                ", Vin='" + Vin + '\'' +
+                ", VIN='" + VIN + '\'' +
                 ", Timestamp='" + Timestamp + '\'' +
                 ", Market='" + Market + '\'' +
                 ", Year=" + Year +
@@ -167,8 +167,8 @@ public class VinDetails {
                 ", DriveType='" + DriveType + '\'' +
                 ", FuelTankSize=" + FuelTankSize +
                 ", EPAFuelEfficiency=" + EPAFuelEfficiency +
-                ", Engine='" + Engine + '\'' +
-                ", Transmission='" + Transmission + '\'' +
+                ", Engine=" + Engine +
+                ", Transmission=" + Transmission +
                 ", Warranties=" + Warranties +
                 ", Recalls=" + Recalls +
                 ", ServiceBulletins=" + ServiceBulletins +

--- a/mojio-sdk-model/src/test/java/io/moj/mobile/android/sdk/model/EntityTests.java
+++ b/mojio-sdk-model/src/test/java/io/moj/mobile/android/sdk/model/EntityTests.java
@@ -2,9 +2,7 @@ package io.moj.mobile.android.sdk.model;
 
 import org.junit.Test;
 
-import io.moj.mobile.android.sdk.model.values.Location;
-
-import static io.moj.mobile.android.sdk.test.TestUtils.assertGettersAndSetters;
+import static io.moj.mobile.android.sdk.test.TestUtils.assertAccess;
 import static io.moj.mobile.android.sdk.test.TestUtils.assertToStringContainsAllFields;
 
 /**
@@ -16,56 +14,56 @@ public class EntityTests {
     public void testApp() throws IllegalAccessException {
         App app = new App();
         assertToStringContainsAllFields(app);
-        assertGettersAndSetters(app);
+        assertAccess(app);
     }
 
     @Test
     public void testGroup() throws IllegalAccessException {
         Group group = new Group();
         assertToStringContainsAllFields(group);
-        assertGettersAndSetters(group);
+        assertAccess(group);
     }
 
     @Test
     public void testListResponse() throws IllegalAccessException {
         ListResponse response = new ListResponse();
         assertToStringContainsAllFields(response);
-        assertGettersAndSetters(response);
+        assertAccess(response);
     }
 
     @Test
     public void testMojio() throws IllegalAccessException {
         Mojio mojio = new Mojio();
         assertToStringContainsAllFields(mojio);
-        assertGettersAndSetters(mojio);
+        assertAccess(mojio);
     }
 
     @Test
     public void testTrip() throws IllegalAccessException {
         Trip trip = new Trip();
         assertToStringContainsAllFields(trip);
-        assertGettersAndSetters(trip);
+        assertAccess(trip);
     }
 
     @Test
     public void testUser() throws IllegalAccessException {
         User user = new User();
         assertToStringContainsAllFields(user);
-        assertGettersAndSetters(user);
+        assertAccess(user);
     }
 
     @Test
     public void testVehicle() throws IllegalAccessException {
         Vehicle vehicle = new Vehicle();
         assertToStringContainsAllFields(vehicle);
-        assertGettersAndSetters(vehicle);
+        assertAccess(vehicle);
     }
 
     @Test
     public void testVehicleMeasure() throws IllegalAccessException {
         VehicleMeasure vehicleMeasure = new VehicleMeasure();
         assertToStringContainsAllFields(vehicleMeasure);
-        assertGettersAndSetters(vehicleMeasure);
+        assertAccess(vehicleMeasure);
     }
 
 }

--- a/mojio-sdk-model/src/test/java/io/moj/mobile/android/sdk/model/requests/RequestTests.java
+++ b/mojio-sdk-model/src/test/java/io/moj/mobile/android/sdk/model/requests/RequestTests.java
@@ -3,7 +3,7 @@ package io.moj.mobile.android.sdk.model.requests;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.moj.mobile.android.sdk.test.TestUtils.assertGettersAndSetters;
+import static io.moj.mobile.android.sdk.test.TestUtils.assertAccess;
 import static io.moj.mobile.android.sdk.test.TestUtils.assertToStringContainsAllFields;
 
 /**
@@ -18,7 +18,7 @@ public class RequestTests {
         assertThat(request.getImei()).isEqualTo(imei);
 
         assertToStringContainsAllFields(request);
-        assertGettersAndSetters(request);
+        assertAccess(request);
     }
 
 }

--- a/mojio-sdk-model/src/test/java/io/moj/mobile/android/sdk/model/values/ValueTests.java
+++ b/mojio-sdk-model/src/test/java/io/moj/mobile/android/sdk/model/values/ValueTests.java
@@ -2,7 +2,7 @@ package io.moj.mobile.android.sdk.model.values;
 
 import org.junit.Test;
 
-import static io.moj.mobile.android.sdk.test.TestUtils.assertGettersAndSetters;
+import static io.moj.mobile.android.sdk.test.TestUtils.assertAccess;
 import static io.moj.mobile.android.sdk.test.TestUtils.assertToStringContainsAllFields;
 
 /**
@@ -13,199 +13,199 @@ public class ValueTests {
     @Test
     public void testAcceleration() throws IllegalAccessException {
         assertToStringContainsAllFields(new Acceleration());
-        assertGettersAndSetters(new Acceleration());
+        assertAccess(new Acceleration());
     }
 
     @Test
     public void testAccelerometer() throws IllegalAccessException {
         assertToStringContainsAllFields(new Accelerometer());
-        assertGettersAndSetters(new Accelerometer());
+        assertAccess(new Accelerometer());
     }
 
     @Test
     public void testAddress() throws IllegalAccessException {
         assertToStringContainsAllFields(new Address());
-        assertGettersAndSetters(new Address());
+        assertAccess(new Address());
     }
 
     @Test
     public void testBattery() throws IllegalAccessException {
         assertToStringContainsAllFields(new Battery());
-        assertGettersAndSetters(new Battery());
+        assertAccess(new Battery());
     }
 
     @Test
     public void testBooleanState() throws IllegalAccessException {
         assertToStringContainsAllFields(new BooleanState());
-        assertGettersAndSetters(new BooleanState());
+        assertAccess(new BooleanState());
     }
 
     @Test
     public void testDiagnosticCode() throws IllegalAccessException {
         assertToStringContainsAllFields(new DiagnosticCode());
-        assertGettersAndSetters(new DiagnosticCode());
+        assertAccess(new DiagnosticCode());
     }
 
     @Test
     public void testDistance() throws IllegalAccessException {
         assertToStringContainsAllFields(new Distance());
-        assertGettersAndSetters(new Distance());
+        assertAccess(new Distance());
     }
 
     @Test
     public void testDuration() throws IllegalAccessException {
         assertToStringContainsAllFields(new Duration());
-        assertGettersAndSetters(new Duration());
+        assertAccess(new Duration());
     }
 
     @Test
     public void testEmail() throws IllegalAccessException {
         assertToStringContainsAllFields(new Email());
-        assertGettersAndSetters(new Email());
+        assertAccess(new Email());
     }
 
     @Test
     public void testEngine() throws IllegalAccessException {
         assertToStringContainsAllFields(new Engine());
-        assertGettersAndSetters(new Engine());
+        assertAccess(new Engine());
     }
 
     @Test
     public void testFuelCapacity() throws IllegalAccessException {
         assertToStringContainsAllFields(new FuelCapacity());
-        assertGettersAndSetters(new FuelCapacity());
+        assertAccess(new FuelCapacity());
     }
 
     @Test
     public void testFuelEfficiency() throws IllegalAccessException {
         assertToStringContainsAllFields(new FuelEfficiency());
-        assertGettersAndSetters(new FuelEfficiency());
+        assertAccess(new FuelEfficiency());
     }
 
     @Test
     public void testFuelLevel() throws IllegalAccessException {
         assertToStringContainsAllFields(new FuelLevel());
-        assertGettersAndSetters(new FuelLevel());
+        assertAccess(new FuelLevel());
     }
 
     @Test
     public void testHeading() throws IllegalAccessException {
         assertToStringContainsAllFields(new Heading());
-        assertGettersAndSetters(new Heading());
+        assertAccess(new Heading());
     }
 
     @Test
     public void testImage() throws IllegalAccessException {
         assertToStringContainsAllFields(new Image());
-        assertGettersAndSetters(new Image());
+        assertAccess(new Image());
     }
 
     @Test
     public void testLocation() throws IllegalAccessException {
         assertToStringContainsAllFields(new Location());
-        assertGettersAndSetters(new Location());
+        assertAccess(new Location());
     }
 
     @Test
     public void testLinkInfo() throws IllegalAccessException {
         assertToStringContainsAllFields(new LinkInfo());
-        assertGettersAndSetters(new LinkInfo());
+        assertAccess(new LinkInfo());
     }
 
     @Test
     public void testMeasurementStatistics() throws IllegalAccessException {
         assertToStringContainsAllFields(new MeasurementStatistics());
-        assertGettersAndSetters(new MeasurementStatistics());
+        assertAccess(new MeasurementStatistics());
     }
 
     @Test
     public void testNextServiceSchedule() throws IllegalAccessException {
         assertToStringContainsAllFields(new NextServiceSchedule());
-        assertGettersAndSetters(new NextServiceSchedule());
+        assertAccess(new NextServiceSchedule());
     }
 
     @Test
     public void testOdometer() throws IllegalAccessException {
         assertToStringContainsAllFields(new Odometer());
-        assertGettersAndSetters(new Odometer());
+        assertAccess(new Odometer());
     }
 
     @Test
     public void testPermission() throws IllegalAccessException {
         assertToStringContainsAllFields(new Permission());
-        assertGettersAndSetters(new Permission());
+        assertAccess(new Permission());
     }
 
     @Test
     public void testPhoneNumber() throws IllegalAccessException {
         assertToStringContainsAllFields(new PhoneNumber());
-        assertGettersAndSetters(new PhoneNumber());
+        assertAccess(new PhoneNumber());
     }
 
     @Test
     public void testProperAcceleration() throws IllegalAccessException {
         assertToStringContainsAllFields(new ProperAcceleration());
-        assertGettersAndSetters(new ProperAcceleration());
+        assertAccess(new ProperAcceleration());
     }
 
     @Test
     public void testRecall() throws IllegalAccessException {
         assertToStringContainsAllFields(new Recall());
-        assertGettersAndSetters(new Recall());
+        assertAccess(new Recall());
     }
 
     @Test
     public void testRpm() throws IllegalAccessException {
         assertToStringContainsAllFields(new Rpm());
-        assertGettersAndSetters(new Rpm());
+        assertAccess(new Rpm());
     }
 
     @Test
     public void testScore() throws IllegalAccessException {
         assertToStringContainsAllFields(new Score());
-        assertGettersAndSetters(new Score());
+        assertAccess(new Score());
     }
 
     @Test
     public void testServiceBulletin() throws IllegalAccessException {
         assertToStringContainsAllFields(new ServiceBulletin());
-        assertGettersAndSetters(new ServiceBulletin());
+        assertAccess(new ServiceBulletin());
     }
 
     @Test
     public void testServiceSchedule() throws IllegalAccessException {
         assertToStringContainsAllFields(new ServiceSchedule());
-        assertGettersAndSetters(new ServiceSchedule());
+        assertAccess(new ServiceSchedule());
     }
 
     @Test
     public void testSpeed() throws IllegalAccessException {
         assertToStringContainsAllFields(new Speed());
-        assertGettersAndSetters(new Speed());
+        assertAccess(new Speed());
     }
 
     @Test
     public void testTransmission() throws IllegalAccessException {
         assertToStringContainsAllFields(new Transmission());
-        assertGettersAndSetters(new Transmission());
+        assertAccess(new Transmission());
     }
 
     @Test
     public void testVinDetails() throws IllegalAccessException {
         assertToStringContainsAllFields(new VinDetails());
-        assertGettersAndSetters(new VinDetails());
+        assertAccess(new VinDetails());
     }
 
     @Test
     public void testVoltage() throws IllegalAccessException {
         assertToStringContainsAllFields(new Voltage());
-        assertGettersAndSetters(new Voltage());
+        assertAccess(new Voltage());
     }
 
     @Test
     public void testWarranty() throws IllegalAccessException {
         assertToStringContainsAllFields(new Warranty());
-        assertGettersAndSetters(new Warranty());
+        assertAccess(new Warranty());
     }
 
 }

--- a/mojio-sdk-model/src/test/java/io/moj/mobile/android/sdk/model/values/ValueTests.java
+++ b/mojio-sdk-model/src/test/java/io/moj/mobile/android/sdk/model/values/ValueTests.java
@@ -191,6 +191,12 @@ public class ValueTests {
     }
 
     @Test
+    public void testVehicleDetails() throws IllegalAccessException {
+        assertToStringContainsAllFields(new VehicleDetails());
+        assertAccess(new VehicleDetails());
+    }
+
+    @Test
     public void testVinDetails() throws IllegalAccessException {
         assertToStringContainsAllFields(new VinDetails());
         assertAccess(new VinDetails());

--- a/mojio-sdk-push/README.md
+++ b/mojio-sdk-push/README.md
@@ -11,7 +11,7 @@ GSON.
 
 ## Download ##
 ```gradle
-compile 'io.moj.mobile.android:mojio-sdk-push:0.0.14'
+compile 'io.moj.mobile.android:mojio-sdk-push:0.0.15'
 ```
 
 ## Instructions ##

--- a/mojio-sdk-push/src/test/java/io/moj/mobile/android/sdk/push/ObserverTest.java
+++ b/mojio-sdk-push/src/test/java/io/moj/mobile/android/sdk/push/ObserverTest.java
@@ -1,18 +1,14 @@
 package io.moj.mobile.android.sdk.push;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 
 import org.junit.Test;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import javax.annotation.Nullable;
 
 import io.moj.mobile.android.sdk.TestJson;
 import io.moj.mobile.android.sdk.test.TestUtils;
@@ -149,7 +145,7 @@ public class ObserverTest {
             if (method.getName().endsWith("Transport"))
                 i.remove();
         }
-        TestUtils.assertGettersAndSetters(o, methods);
+        TestUtils.assertAccess(o, methods);
 
         o.setTransport(null);
         assertNull(o.getTransport());

--- a/mojio-sdk-test/src/main/java/io/moj/mobile/android/sdk/test/TestUtils.java
+++ b/mojio-sdk-test/src/main/java/io/moj/mobile/android/sdk/test/TestUtils.java
@@ -57,11 +57,11 @@ public final class TestUtils {
         }
     }
 
-    public static void assertGettersAndSetters(Object pojo) {
-        assertGettersAndSetters(pojo, getAllMethods(pojo));
+    public static void assertAccess(Object pojo) {
+        assertAccess(pojo, getAllMethods(pojo));
     }
 
-    public static void assertGettersAndSetters(Object pojo, List<Method> methods) {
+    public static void assertAccess(Object pojo, List<Method> methods) {
         Set<String> methodNames =
                 new HashSet<>(Lists.transform(methods, FUNCTION_EXTRACT_METHOD_NAMES));
 
@@ -69,6 +69,8 @@ public final class TestUtils {
         for (Field field : fields) {
             if (Modifier.isStatic(field.getModifiers()))
                 continue;
+
+            assertThat(Modifier.isPrivate(field.getModifiers())).isTrue();
 
             String fieldName = field.getName();
             if (fieldName.startsWith("_")) {


### PR DESCRIPTION
- Split Vehicle.getVinDetails() to return a VehicleDetails object instead of a VinDetails object as a workaround for MOJIO-857.
- Added missing 'RiskSeverity' field to FuelLevel
- Changed DiagnosticCode members to be private (likely a copy-paste mistake before). Added an assertion in unit tests to ensure members are private going forwards.
- Made MojioObject an interface and split common functionality into AbstractMojioObject. This enables easier customization/extension of the SDK if required (I have a specific example regarding database persistence I can share offline).
- Tagged as version 0.0.15
